### PR TITLE
Fix update script to use the correct git remote label

### DIFF
--- a/scripts/configure-vm/update-vm
+++ b/scripts/configure-vm/update-vm
@@ -4,7 +4,7 @@ while true; do
     case $yn in
            [Yy]* )
 	   cd /xGDBvm
-           sudo git pull origin master;
+           sudo git pull origin upstream;
             echo ""
               echo "The code has been updated from the github repository."
             echo ""


### PR DESCRIPTION
Currently, the repo in the iPlant image has one remote labeled `origin` which is pointing to the central BrendelGroup xGDBvm repository. To be more consistent with our development workflow, we should rename this remote to `upstream`. For our own personal development, we should set `origin` to our respective GitHub forks (Jon's origin is `jduvick/xGDBvm`, Daniel's is `standage/xGDBvm`, and so on).

When creating a new image, we should remove the `origin` remote and `/root/.gitconfig` before imaging.
