### PR TITLE
updates to mount-datastore, xGDB_Procedure.pl, SplitMakeArrayGSQ.pl

### DIFF
--- a/scripts/SplitMakeArrayGSQ.pl
+++ b/scripts/SplitMakeArrayGSQ.pl
@@ -1,0 +1,163 @@
+#! /usr/bin/perl -w
+#
+# SplitMakeArrayGSQ.pl
+#   - script invoked by xGDB_Procedure.sh to split a transcript file into smaller chunks,
+#     run MakeArray, and launch GeneSeqer or (if the machine has more than 1 processor) GeneSeqerMPI
+
+use strict;
+my $binDIR='/usr/local/bin/';
+
+# Set $np to the number of processors on the machine:
+#
+my $np = `cat /proc/cpuinfo | grep processor | wc -l`;
+chomp $np;
+
+# Variables
+#
+my $seqHeader = "";		#The current sequence header
+my $sequence = "";		#The current sequence
+my $seqLength = 0.0;		#The current sequence length in Mb
+my $curFileLength = 0.0;	#The current file length in Mb
+my $fileCount = 1;		#The count of output files made
+my $filename;			#The name of the input file
+my $maxLength;			#The specified maximal file length in Mb
+my $wasSeq = 0;			#Flag for sequence construction
+my $genomeFile;			#query file for GeneSeqer
+my $WorkPath;
+my $xGDB = 'GDB000';
+my $TypeTag;
+my $RNAFastaType = '';		#D or d according to header type
+my $DNAFastaType = '';		#L or l according to header typen(under development)
+my $GeneSeqer = '';
+my $GSQparameters;
+
+if ($np > 1) {
+ 	$GeneSeqer = "/usr/lib64/openmpi/bin/mpirun -np $np /usr/local/bin/GeneSeqerMPI";
+} else {
+	$GeneSeqer = "/usr/local/bin/GeneSeqer";
+}
+
+# Read command-line arguments:
+#
+if ($ARGV[0] ne \0 && $ARGV[1] != \0 && $ARGV[2] ne \0 && $ARGV[3] ne \0 ) { 	#The correct number of parameters were given
+	$filename = $ARGV[0];
+	$maxLength = $ARGV[1];
+	$genomeFile = $ARGV[2];
+	$GSQparameters = $ARGV[3];
+	if ($maxLength !~ /\d+/) {				#Check for correct type: numeric
+		print "Second parameter must be numeric!\n";
+		exit;
+	}
+}
+
+open my $file, '<', "$genomeFile"; 
+my $firstLine = <$file>; 
+if ($DNAFastaType eq '' && $firstLine =~ /^>gi\|\d+/)  { #test for GenBank gi format if not already set
+	$DNAFastaType = '-l ';
+	print "GenBank formatted genome";
+}elsif($DNAFastaType eq '' && $firstLine =~ /^>\S+/){ #test for non-GenBank gi format if not already set
+	$DNAFastaType = '-L ';
+	print "non-GenBank formatted genome";
+}else{
+	$DNAFastaType = '-L ';
+}
+close $file;
+
+if ($filename =~ /(\/xGDBvm\/data\/scratch\/)(GDB\d\d\d)/){ # scratch directory
+	$WorkPath = $1.$2;
+	$xGDB=$2;
+}
+if ($filename =~ /(\/xGDBvm\/data\/)(GDB\d\d\d)/){ # data output directory (currently addGSEG uses this)
+	$WorkPath = $1.$2;
+	$xGDB=$2;
+}
+
+# Split input transcript file into smaller chunks:
+#
+if ($filename =~ /est/){
+	$TypeTag = 'est';
+}elsif ($filename =~ /cdna/){
+        $TypeTag = 'cdna';
+}elsif ($filename =~ /tsa/){ # changed from 'put' on 4/25/13 to synch with file naming updates in xGDB_Procedure.sh
+        $TypeTag = 'tsa';
+}
+my $DB = "$filename$fileCount";
+
+open (IN, "<$filename");
+open (OUT, ">$filename$fileCount");
+	
+while (<IN>) {
+
+	if ($RNAFastaType eq '' && $_ =~ /^>gi\|\d+/)  { #test for GenBank gi format if not already set
+		$RNAFastaType = '-d ';
+		print "GenBank formatted transcripts";
+	}elsif($RNAFastaType eq '' && $_ =~ /^>\S+/){ #test for non-GenBank gi format if not already set
+		$RNAFastaType = '-D ';
+		print "non-GenBank formatted transcripts";
+	}
+
+	if ($_ =~ /^[>;\s]/) {	#Gets header and comments -> $seqHeader
+		if ($wasSeq) {
+			$wasSeq = 0;
+			printToFile();
+		} 
+		$seqHeader .= $_;	#Captures entire line, including white space
+		next;
+	}
+	elsif ($_ =~ /(\w+)/) {	#Gets just the sequence, no whitespace
+		$sequence .=  $&;
+		$wasSeq = 1;
+		next;
+	}
+	else {
+		print "I don't know how the code got here.  lineIn did not match pattern.\n";
+		exit;
+	}
+}
+
+printToFile();
+print "File: $filename$fileCount"." created. Approximate cumulative length: %6.2f Mb\n", $curFileLength;
+close OUT;
+
+# Invoke MakeArray to prepare transcript index files:
+#
+my @dblist= split (/ /,$DB);
+foreach my $db (@dblist){
+	system ("$binDIR/MakeArray $db");
+}
+
+$DB = $RNAFastaType.$DB;
+$DB =~ s/\n//;
+
+# Run GeneSeqer(MPI):
+#
+my $command ="$GeneSeqer $DB $GSQparameters -O ${WorkPath}/data/GSQ/GSQOUT/${xGDB}${TypeTag}.gsq $DNAFastaType $genomeFile";
+system($command);
+
+
+# Functions:
+#
+sub printToFile {
+	$seqLength = length($sequence)/1000000.0;
+	if ( $curFileLength > 0.0  &&  ($seqLength + $curFileLength) > $maxLength) {	#If maxLength will be exceeded, close current outFile and and open a new one.
+		close OUT;
+		print "File: $filename$fileCount"." created. Length: $curFileLength Mb\n";
+		$curFileLength = 0.0;
+		$fileCount++;
+		open (OUT, ">$filename$fileCount");
+		$DB .= " $filename$fileCount";
+	}
+	
+	#Write sequence to file and update $curFileLength
+	#
+	print OUT "$seqHeader$sequence\n";
+	$curFileLength += $seqLength;
+	$sequence = "";
+	$seqHeader = "";
+}
+
+sub short {
+	my ($file) = @_;
+	$file =~ /(\w+)/;
+	return $&;
+}

--- a/scripts/configure-vm/mount-datastore
+++ b/scripts/configure-vm/mount-datastore
@@ -2,7 +2,7 @@
 input_dir="/home/xgdb-input"
 
 while true; do
-    echo ""; read -p "Mount your Data Store at $input-dir? [y/n]: " yn
+    echo ""; read -p "Mount your Data Store at $input_dir? [y/n]: " yn
     case $yn in
         [Yy]* ) irodsFs $input_dir -o max_readahead=0 -o allow_other -o nonempty;
            success=$(df -kh | egrep -o  -s 'fuse|irodsFs'); 

--- a/scripts/xGDB_Procedure.sh
+++ b/scripts/xGDB_Procedure.sh
@@ -756,7 +756,7 @@ FirstPart() {
    # Cycle through all transcript types in series (est, cdna, tsa, prot)
    # 1. If present, copy user-provided (pre-computed) transcript GeneSeqer/GenomeThreader output files to scratch directory
    # 2. Else no user-provided GeneSeqer/GenomeThreader output files, check Remote Processing flag. If present, initiate Remote process and copy output to scratch directory.
-   # 3. Else no Remote Processing, initiates splitMakearryGSQ.pl locally (parses input, makes index, initiates GeneSeqer), or GenomeThreader locally, deposit output in scratch directory
+   # 3. Else no Remote Processing, initiates SplitMakeArrayGSQ.pl locally (parses input, makes index, initiates GeneSeqer), or GenomeThreader locally, deposit output in scratch directory
    # 4. Check for GSQ/GTH output in scratch directory and report result.
    # NOTE: Parsing and uploading occur later after all data types are processed.
    
@@ -1304,12 +1304,12 @@ FirstPart() {
                 
                if [ "$PRG" == "GSQ" ]
                then
-                  # GSQ: Start INTERNAL Spliced Alignment Process using splitMakearry${PRG}.pl with "Internal" flag  (Splits transcript into 70K chunks, index and then launch GeneSeqer on local processor)
+                  # GSQ: Start INTERNAL Spliced Alignment Process using SplitMakeArray${PRG}.pl with "Internal" flag (splits transcript file into 70Mib chunks, creates index, and then launches GeneSeqer on local processors)
                   dateTime825=$(date +%Y-%m-%d\ %k:%M:%S)
                   msg825="${tRN} spliced-alignment to genome initiated locally using /xGDBvm/scripts/splitMakearry${PRG}.pl: "
                   echo "$space$msg825$dateTime825 (8.25)">>$WorkDIR/logs/Pipeline_procedure.log
                   echo " - ${PRG} parameter set is $PRGparameter " >>$WorkDIR/logs/Pipeline_procedure.log       
-                  /xGDBvm/scripts/splitMakearryGSQ.pl $tmpWorkDIR/data/GSQ/${DIR}/${xGDB}${trn}.fa 70 $tmpWorkDIR/data/GSQ/SCFDIR/${xGDB}gdna.fa "$GSQparameter"
+                  /xGDBvm/scripts/SplitMakeArrayGSQ.pl $tmpWorkDIR/data/GSQ/${DIR}/${xGDB}${trn}.fa 70 $tmpWorkDIR/data/GSQ/SCFDIR/${xGDB}gdna.fa "$GSQparameter"
                fi
                if [ "$PRG" == "GTH" ]
                then
@@ -2649,7 +2649,7 @@ addGSEG () {
    echo "- EST Spliced Alignment: $countU206a EST sequences are being splice-aligned to $countU206b new genome sequences (U2.06)" >>$WorkDIR/logs/Pipeline_procedure.log
    echo "${space} GSQ parameter set is $GSQparameter (U2.06)" >>$WorkDIR/logs/Pipeline_procedure.log
    
-   /xGDBvm/scripts/splitMakearryGSQ.pl ${WorkDIR}/data/GSQ/MRNADIR/${xGDB}est.fa 70 ${WorkDIR}/data/GSQ/SCFDIR/new_${xGDB}gdna.fa "$GSQparameter"
+   /xGDBvm/scripts/SplitMakeArrayGSQ.pl ${WorkDIR}/data/GSQ/MRNADIR/${xGDB}est.fa 70 ${WorkDIR}/data/GSQ/SCFDIR/new_${xGDB}gdna.fa "$GSQparameter"
    
    #U2.07 EST GeneSeqer results with new scaffolds
    dateTimeU207=$(date +%Y-%m-%d\ %k:%M:%S)
@@ -2665,7 +2665,7 @@ addGSEG () {
    echo "- cDNA Spliced Alignment: $countU208a cDNA sequences are being splice-aligned to $countU208b new genome sequences (U2.08)" >>$WorkDIR/logs/Pipeline_procedure.log
    echo "${space}GSQ parameter set is $GSQparameter (U2.08)" >>$WorkDIR/logs/Pipeline_procedure.log
    
-   /xGDBvm/scripts/splitMakearryGSQ.pl ${WorkDIR}/data/GSQ/MRNADIR/${xGDB}cdna.fa 70 ${WorkDIR}/data/GSQ/SCFDIR/new_${xGDB}gdna.fa "$GSQparameter"
+   /xGDBvm/scripts/SplitMakeArrayGSQ.pl ${WorkDIR}/data/GSQ/MRNADIR/${xGDB}cdna.fa 70 ${WorkDIR}/data/GSQ/SCFDIR/new_${xGDB}gdna.fa "$GSQparameter"
    
    #U2.09 cDNA GeneSeqer results with new scaffolds
    
@@ -2682,7 +2682,7 @@ addGSEG () {
    echo "- TSA Spliced Alignment: $countU210a TSA sequences are being splice-aligned to $countU210b new genome sequences (U2.08)" >>$WorkDIR/logs/Pipeline_procedure.log
    echo "${space}GSQ parameter set is $GSQparameter (U2.10)" >>$WorkDIR/logs/Pipeline_procedure.log
    
-   /xGDBvm/scripts/splitMakearryGSQ.pl ${WorkDIR}/data/GSQ/PUTDIR/${xGDB}tsa.fa 70 ${WorkDIR}/data/GSQ/SCFDIR/new_${xGDB}gdna.fa "$GSQparameter"
+   /xGDBvm/scripts/SplitMakeArrayGSQ.pl ${WorkDIR}/data/GSQ/PUTDIR/${xGDB}tsa.fa 70 ${WorkDIR}/data/GSQ/SCFDIR/new_${xGDB}gdna.fa "$GSQparameter"
    
    #U2.11 TSA GeneSeqer results with new scaffolds
    
@@ -2831,7 +2831,7 @@ addEST () {
       echo "${space}Skipping GeneSeqer spliced alignment, jumping to U3.08">>$WorkDIR/logs/Pipeline_procedure.log
    else
       
-      ## If no user-provided GeneSeqer output files, initiates splitMakearryGSQ.pl (parses input, makes index, initiates GeneSeqer), deposits output in working directory
+      ## If no user-provided GeneSeqer output files, initiates SplitMakeArrayGSQ.pl (parses input, makes index, initiates GeneSeqer), deposits output in working directory
       
       ## U3.07 Split and run GeneSeqer on scratch directory
       
@@ -2840,7 +2840,7 @@ addEST () {
       echo "$space$countU307$msgU307$dateTimeU307 (U3.07)">>$WorkDIR/logs/Pipeline_procedure.log
       echo "${space}GSQ parameter set is $GSQparameter (U3.07)" >>$WorkDIR/logs/Pipeline_procedure.log
       
-      /xGDBvm/scripts/splitMakearryGSQ.pl $tmpWorkDIR/data/GSQ/MRNADIR/${xGDB}est.fa 70 $tmpWorkDIR/data/GSQ/SCFDIR/${xGDB}gdna.fa "$GSQparameter" $GSQ_CompResources  # Output will be sent to $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}est.gsq
+      /xGDBvm/scripts/SplitMakeArrayGSQ.pl $tmpWorkDIR/data/GSQ/MRNADIR/${xGDB}est.fa 70 $tmpWorkDIR/data/GSQ/SCFDIR/${xGDB}gdna.fa "$GSQparameter" $GSQ_CompResources  # Output will be sent to $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}est.gsq
       
       countU3075=$(grep -c "MATCH" $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}est.gsq)
       msgU3075=" EST spliced alignments (not filtered for quality) completed and sent to GSQ output directory $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}est.gsq "
@@ -2992,7 +2992,7 @@ addCDNA () {
       echo "${space}Skipping GeneSeqer spliced alignment, jumping to U4.08">>$WorkDIR/logs/Pipeline_procedure.log
    else
       
-      ## If no user-provided GeneSeqer output files, initiates splitMakearryGSQ.pl (parses input, makes index, initiates GeneSeqer), deposits output in working directory
+      ## If no user-provided GeneSeqer output files, initiates SplitMakeArrayGSQ.pl (parses input, makes index, initiates GeneSeqer), deposits output in working directory
       
       ## U4.07 Split and run GeneSeqer on scratch directory
       
@@ -3001,7 +3001,7 @@ addCDNA () {
       echo "$space$countU407$msgU407$dateTimeU407 (U4.07)">>$WorkDIR/logs/Pipeline_procedure.log
       echo "${space}GSQ parameter set is $GSQparameter (U4.07)" >>$WorkDIR/logs/Pipeline_procedure.log
       
-      /xGDBvm/scripts/splitMakearryGSQ.pl $tmpWorkDIR/data/GSQ/MRNADIR/${xGDB}cdna.fa 70 $tmpWorkDIR/data/GSQ/SCFDIR/${xGDB}gdna.fa "$GSQparameter" $GSQ_CompResources  # Output will be sent to $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}cdna.gsq
+      /xGDBvm/scripts/SplitMakeArrayGSQ.pl $tmpWorkDIR/data/GSQ/MRNADIR/${xGDB}cdna.fa 70 $tmpWorkDIR/data/GSQ/SCFDIR/${xGDB}gdna.fa "$GSQparameter" $GSQ_CompResources  # Output will be sent to $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}cdna.gsq
       
       countU4075=$(grep -c "MATCH" $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}cdna.gsq)
       msgU4075=" cDNA spliced alignments (not filtered for quality) completed and sent to GSQ output directory $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}cdna.gsq "
@@ -3156,7 +3156,7 @@ addTSA () {
       echo "${space}Skipping GeneSeqer spliced alignment, jumping to U5.08">>$WorkDIR/logs/Pipeline_procedure.log
    else
       
-      ## If no user-provided GeneSeqer output files, initiates splitMakearryGSQ.pl (parses input, makes index, initiates GeneSeqer), deposits output in working directory
+      ## If no user-provided GeneSeqer output files, initiates SplitMakeArrayGSQ.pl (parses input, makes index, initiates GeneSeqer), deposits output in working directory
       
       ## U5.07 Split and run GeneSeqer on scratch directory
       
@@ -3165,7 +3165,7 @@ addTSA () {
       echo "$space$countU507$msgU507$dateTimeU507 (U5.07)">>$WorkDIR/logs/Pipeline_procedure.log
       echo "${space}GSQ parameter set is $GSQparameter (U5.07)" >>$WorkDIR/logs/Pipeline_procedure.log
       
-      /xGDBvm/scripts/splitMakearryGSQ.pl $tmpWorkDIR/data/GSQ/PUTDIR/${xGDB}tsa.fa 70 $tmpWorkDIR/data/GSQ/SCFDIR/${xGDB}gdna.fa "$GSQparameter" $GSQ_CompResources  # Output will be sent to $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}tsa.gsq
+      /xGDBvm/scripts/SplitMakeArrayGSQ.pl $tmpWorkDIR/data/GSQ/PUTDIR/${xGDB}tsa.fa 70 $tmpWorkDIR/data/GSQ/SCFDIR/${xGDB}gdna.fa "$GSQparameter" $GSQ_CompResources  # Output will be sent to $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}tsa.gsq
       
       countU5075=$(grep -c "MATCH" $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}tsa.gsq)
       msgU5075=" TSA spliced alignments (not filtered for quality) completed and sent to GSQ output directory $tmpWorkDIR/data/GSQ/GSQOUT/${xGDB}tsa.gsq "


### PR DESCRIPTION
mount-datastore: I fixed a trivial typo

xGDB_Procdure.pl: this is an important change - we now call SplitMakeArrayGSQ.pl; the old script splitMakearryGSQ.pl should be deleted

SplitMakeArrayGSQ.p: this new script fixes a problem with the splitting of input files, but more importantly, it now launches GeneSeqerMPI on VMs with multiple processors; this requires an updated image that properly includes openmpi and compilation of GeneSeqer with the MPI version
