### PR TITLE
Bug fixes including failure to parse N-mask in genomic input and new condition for remote job failure

### DIFF
--- a/XGDB/conf/viewall.php
+++ b/XGDB/conf/viewall.php
@@ -317,7 +317,6 @@ $display_block .= "<table class=\"featuretable bottommargin1 striped\" style=\"f
 					<th>Home</th>
 					<th>Sample <br /> region</th>
 					<th>Down  <br /> loads</th>
-					<th class=\"$display_if_lock\">Tmp  <br /> Dir</th>
 					<th>Log Files <br /></th>
 					<th class=\"smallerfont\" >GDB</th>
 					<th class=\"smallerfont\" >All</th>

--- a/scripts/parseGsegMask.pl
+++ b/scripts/parseGsegMask.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-## Updated 6/12/14 
+## Updated 2/19/16 
 ##SYNTAX
 print("Usage: ./$0 <unmasked_file> <masked_file> <sql_output> <fasta_output> <base>\n");
 
@@ -47,87 +47,89 @@ while (<MASK>)
 
     if (@pieces=($line1 =~ /^>gi\|(\d+?)\|(.*?)\n.+/))
     {  ## regex for a GenBank fasta header with line feed, e.g. >gi|12345|gb|ABC123| This is description\n
-	##TODO: Set the gi, and other details from this.
-		$gi_line = ">gi|".$pieces[0].$pieces[1];
-		$gi = $pieces[0];
-		$desc = $pieces[1];
-		$M = 0; # first sequence, closest to header.
-		$valid="T";
-		$heading="GenBank";
-		
-#	   print "gi=$gi; gi_line=$gi_line; desc=$desc; M=$M; heading=$heading; length=$length; line1=$line1;\n";
-	}
-	elsif(@pieces=($line1 =~ /^>(\S+?)([^\S\n]+?\S+?)\n.*?/)) # [^\S\n] means not not whitespace and not newline
-	{  ## regex for a non-GenBank fasta header with description and line feed, e.g. >scaff_12345 This is description\n
-		$gi_line = ">".$pieces[0].$pieces[1];
-		$gi = $pieces[0];
-		$desc = $pieces[1];
-		$M = 0;
-		$valid="T";
-		$heading="simple with description";
-#	    print "gi=$gi;  gi_line=$gi_line; desc=$desc; M=$M; heading=$heading; line1=$line1\n";
-	}
-	elsif(@pieces=($line1 =~ /^>(\S+?)\n.*/))
-	{  ## regex for a non-GenBank fasta header with description and line feed, e.g. >scaff_12345 This is description\n
-		$gi_line = ">".$pieces[0].$pieces[1];
-		$gi = $pieces[0];
-		$desc = "";
-		$M = 0;
-		$valid="T";
-		$heading="simple with no description";
-#	   print "gi=$gi;  gi_line=$gi_line; desc=$desc; M=$M;  heading=$heading; line1=$line1\n";
-	}
-	else
-	{
-	print "Error: This unmasked fasta header cannot be read. line1=$line1\n";
-		$valid="F";
-	}
+    ##TODO: Set the gi, and other details from this.
+        $gi_line = ">gi|".$pieces[0].$pieces[1];
+        $gi = $pieces[0];
+        $desc = $pieces[1];
+        $M = 0; # first sequence, closest to header.
+        $valid="T";
+        $heading="GenBank";
+        
+#      print "gi=$gi; gi_line=$gi_line; desc=$desc; M=$M; heading=$heading; length=$length; line1=$line1;\n";
+    }
+    elsif(@pieces=($line1 =~ /^>(\S+?)\s+(.+?)\n.*?/)) #
+    {  ## regex for a non-GenBank fasta header with description and line feed, e.g. >scaff_12345 This is description\n
+    
+       ## >NW_003307545.1 Volvox carteri f. nagariensis unplaced genomic scaffold VOLCAscaffold_1, whole genome shotgun sequence
+        $gi_line = ">".$pieces[0].$pieces[1];
+        $gi = $pieces[0];
+        $desc = $pieces[1];
+        $M = 0;
+        $valid="T";
+        $heading="simple with description";
+#       print "gi=$gi;  gi_line=$gi_line; desc=$desc; M=$M; heading=$heading; line1=$line1\n";
+    }
+    elsif(@pieces=($line1 =~ /^>(\S+?)\n.*/))
+    {  ## regex for a non-GenBank fasta header with no description and line feed, e.g. >scaff_12345\n
+        $gi_line = ">".$pieces[0].$pieces[1];
+        $gi = $pieces[0];
+        $desc = "";
+        $M = 0;
+        $valid="T";
+        $heading="simple with no description";
+#      print "gi=$gi;  gi_line=$gi_line; desc=$desc; M=$M;  heading=$heading; line1=$line1\n";
+    }
+    else
+    {
+    print "Error: This unmasked fasta header cannot be read. line1=$line1\n";
+        $valid="F";
+    }
 
-	## assign line1 to the sequence (non-header) portion of the line.
-	$seq1 = substr($line1, length($gi_line) + 1, length($line1) - length($gi));
-	$seq1_stripped = $seq1;
-	$seq1_stripped =~ s/\n//g; ## strip linefeeds
+    ## assign line1 to the sequence (non-header) portion of the line.
+    $seq1 = substr($line1, length($gi_line) + 1, length($line1) - length($gi));
+    $seq1_stripped = $seq1;
+    $seq1_stripped =~ s/\n//g; ## strip linefeeds
 #    print "seq1_stripped=$seq1_stripped\n\n";
 
 
-	if($valid eq "T")
-	{
-		#Search the MASK string for sequences of X+
-		##Record the matches, and construct the SQL statements.
-		while ($seq1_stripped =~ /(${base}+)/g) 
-		{
-			$M = $M + 1;
-			print $-[0]." ".$+[0]."\n";
-			$lpos = $-[0] + 1;
-			$rpos = $+[0];
-			$subseq1=`/usr/local/bin/blastdbcmd -db $rawfile -entry $gi -range ${lpos}-${rpos} -outfmt %s`;
-			if($subseq1 =~ /(\S+)\n/)
-			{
-			  $subseq1 = $1;
-			}
-			#$seq=chomp($seq);
+    if($valid eq "T")
+    {
+        #Search the MASK string for sequences of X+
+        ##Record the matches, and construct the SQL statements.
+        while ($seq1_stripped =~ /(${base}+)/g) 
+        {
+            $M = $M + 1;
+            print $-[0]." ".$+[0]."\n";
+            $lpos = $-[0] + 1;
+            $rpos = $+[0];
+            $subseq1=`/usr/local/bin/blastdbcmd -db $rawfile -entry $gi -range ${lpos}-${rpos} -outfmt %s`;
+            if($subseq1 =~ /(\S+)\n/)
+            {
+              $subseq1 = $1;
+            }
+            #$seq=chomp($seq);
 
-			$subseq2=`/usr/local/bin/blastdbcmd -db $maskfile -entry $gi -range ${lpos}-${rpos} -outfmt %s`;
-			if($subseq2 =~ /(\S+)\n/)
-			{
-			  $subseq2 = $1;
-			}
-			if($subseq1 eq $subseq2) # was already N-string
-			{
-			  $isMask="False";
-			  $maskType="Unknown bases";
-			}
-			else
-			{
-			  $isMask="True";
-			  $maskType="Repeat Masked Region";
-			}
-			  printsql($gi, $M, $desc, $subseq1, $lpos, $rpos, $isMask, $maskType);
-#		print "gi=$gi, M=$M, desc=$desc, seq=$seq, lpos=$lpos, rpos=$rpos\n\n";
-		}
-		$start = tell MASK;  ## NEW START, from where the pointer was, includes line feeds.
-		print "NEW START=$start\n\n";
-	}
+            $subseq2=`/usr/local/bin/blastdbcmd -db $maskfile -entry $gi -range ${lpos}-${rpos} -outfmt %s`;
+            if($subseq2 =~ /(\S+)\n/)
+            {
+              $subseq2 = $1;
+            }
+            if($subseq1 eq $subseq2) # was already N-string
+            {
+              $isMask="False";
+              $maskType="Unknown bases";
+            }
+            else
+            {
+              $isMask="True";
+              $maskType="Repeat Masked Region";
+            }
+              printsql($gi, $M, $desc, $subseq1, $lpos, $rpos, $isMask, $maskType);
+#       print "gi=$gi, M=$M, desc=$desc, seq=$seq, lpos=$lpos, rpos=$rpos\n\n";
+        }
+        $start = tell MASK;  ## NEW START, from where the pointer was, includes line feeds.
+        print "NEW START=$start\n\n";
+    }
 }
 
 close MASK;

--- a/scripts/xGDB_Procedure.sh
+++ b/scripts/xGDB_Procedure.sh
@@ -1087,7 +1087,7 @@ FirstPart() {
                      
                      # job_status="running" ###### DEBUG ONLY #######
                      
-                     if [[ "$job_status" == "RUNNING" || "$job_status" == "FAILED" || "$job_status" == "KILLED"  || "$job_status" == "STOPPED" || "$job_status" == "PAUSED" ]] # Which means status is no longer submitting, processing_inputs, queued
+                     if [[ "$job_status" == "RUNNING" || "$job_status" == "FAILED" || "$job_status" == "KILLED"  || "$job_status" == "STOPPED" || "$job_status" == "PAUSED" || "$job_status" == "FINISHED" ]] # Which means status is no longer submitting, processing_inputs, queued. Added 'FINISHED' to the choices since sometimes a failed job skips to this status 2-18-16 
                      
                      then
                         dateTime856=$(date +%Y-%m-%d\ %k:%M:%S)


### PR DESCRIPTION
The N-mask failure was due to an incorrectly constructed regular expression that was attempting to parse a fasta header of type `>id12345 this is the description`. 

The update to `xGDB_Procedure.sh` was made because I observed yet another flavor of job failure (some kind of server connection issue perhaps?)  in which RUNNING status is never reported and the end status FINISHED is reached all the same. So we need to stop waiting for RUNNING status if we ever see FINISHED. Absence of output will still result in an error message but at least we won't wait 12 hrs to get it. 

The `viewall.php` update was a leftover style feature now deprecated but still affecting column alignment when a GDB was 'Locked'.
