### PR TITLE
Fixed bug in copy_exec.php

### DIFF
--- a/XGDB/jobs/copy_exec.php
+++ b/XGDB/jobs/copy_exec.php
@@ -43,8 +43,8 @@ date_default_timezone_set("$TIMEZONE"); // from sitedef.php
 if(isset($_POST['job']) && isset($_POST['return'])) 
 {
 
-// validate job id, e.g. 0001424105021858-5056a550b8-0001-007, and get valid nonce to compare with posted value.
-    $pattern='/^\d{16}-[a-z0-9]{10}-\d{4}-\d{3}$/';
+// validate job id, e.g. 3407263385550908955-242ac113-0001-007, and get valid nonce to compare with posted value.
+    $pattern='/^\d+-[a-z0-9]+-\d+-\d+$/'; # 2-20-16 I made this check more generic as the structure of this ID string seems to change periodically.
     if(preg_match($pattern, $job_id)) # second level check
     {
 


### PR DESCRIPTION
The updated code is to validate a POSTed job ID, currently in the form of a string like:
`3407263385550908955-242ac113-0001-007`. At some point last fall the structure of the string changed, as can be seen in the diff below, thus breaking my validation. In my update I made the validation regex more generic so as to avoid the problem if small changes are made in future.
