### PR TITLE
updated to include code that specifies persistent notifications 

### DIFF
--- a/XGDB/jobs/gsq_job.php
+++ b/XGDB/jobs/gsq_job.php
@@ -224,43 +224,8 @@ else
 
 //Setting post array that we will jsonify. See http://agaveapi.co/live-docs/#!/jobs/submit_post_1
 
-//If amin_email missing, don't include email webhooks.
+$notifications = build_notifications_array($callbackUrl, $admin_email); # see jobs_functions.inc.php; an array for alerts to the VM / user (if admin email configured)
 
-$notifications=($admin_email=="")
-?
-array
-	   (
-			array(
-			   "url" =>  "$callbackUrl",
-			   "event" => "*",
-			   "persistent" => true
-			)
-		)
-:
-array
-	   (
-		   array(
-				 "url" => "$admin_email",
-				 "event" => "RUNNING",
-			   "persistent" => false
-			),
-			array(
-			   "url" => "$admin_email",
-			   "event" =>  "FINISHED",
-			   "persistent" => false
-			),
-			array(
-			   "url" => "$admin_email",
-			   "event" =>  "FAILED",
-			   "persistent" => false
-			),
-			array(
-			   "url" =>  "$callbackUrl",
-			   "event" => "*",
-			   "persistent" => true
-			)
-		)
-;
 //create array
 	$job_data = array
 	(

--- a/XGDB/jobs/gth_job.php
+++ b/XGDB/jobs/gth_job.php
@@ -1,4 +1,4 @@
-<?php // Latest update: 6-19-15 JPD
+<?php // Latest update: 7-11-16 JDuvick 
 error_reporting(E_ALL & ~E_NOTICE); //disable undeclared variable error
 // Start the php session to be able to pull login and password tokens
 	session_start();
@@ -170,43 +170,8 @@ else
 
 //Setting post array that we will jsonify. See http://agaveapi.co/live-docs/#!/jobs/submit_post_1
 
-//If amin_email missing, don't include email webhooks.
+$notifications = build_notifications_array($callbackUrl, $admin_email); # see jobs_functions.inc.php; an array for alerts to the VM / user (if admin email configured)
 
-$notifications=($admin_email=="")
-?
-array
-	   (
-			array(
-			   "url" =>  "$callbackUrl",
-			   "event" => "*",
-			   "persistent" => true
-			)
-		)
-:
-array
-	   (
-		   array(
-				 "url" => "$admin_email",
-				 "event" => "RUNNING",
-			   "persistent" => false
-			),
-			array(
-			   "url" => "$admin_email",
-			   "event" =>  "FAILED",
-			   "persistent" => false
-			),
-			array(
-			   "url" => "$admin_email",
-			   "event" =>  "FINISHED",
-			   "persistent" => false
-			),
-			array(
-			   "url" =>  "$callbackUrl",
-			   "event" => "*",
-			   "persistent" => true
-			)
-		)
-;
 //create array
 	$job_data = array
 	(

--- a/XGDB/jobs/jobs_functions.inc.php
+++ b/XGDB/jobs/jobs_functions.inc.php
@@ -1,5 +1,5 @@
 <?php
-
+# updated 7-11-2016 JDuvick 
 
 ################
 # Data Display #
@@ -22,29 +22,29 @@ return $job_name_stripped;
 
 //build dropdown of Development GDB  (from session if available as the selected one)
 
-	function gdb_external_dropdown($current){
-	
-		$gdb_dropdown_result="<option value=\"\">- Select a GDB -</option>\n\n";
-		$gdbQuery="SELECT distinct ID, DBname, Status FROM Genomes.xGDB_Log where (Status = 'Development' OR Status = 'Locked') order by ID";
-		$get_gdb = $gdbQuery;
-		$check_get_gdb = mysql_query($get_gdb);
-		$ID="";
-		$DBname="";
-		$Status="";
-		$selected="";
-		while ($gdb_data = mysql_fetch_array($check_get_gdb)) {
-				$ID = $gdb_data['ID'];
-				$DBid = "GDB".substr(('00'.$ID), -3);
-				$selected=($DBid==$current)?' selected="\"selected\"" ':'';
-				$DBname = $gdb_data['DBname'];	
-				$DBname = substr($DBname, 0, 30); //truncate long GDB name to fit better on page
-				
-				$Status = $gdb_data['Status'];	
-				$Stat = substr($Status, 0, 3);
-				$gdb_dropdown_result.= "<option $selected value=\"$ID\">$DBid (${Stat}) $DBname</option>\n\n";
-			}	
-			
-			return $gdb_dropdown_result;
+    function gdb_external_dropdown($current){
+    
+        $gdb_dropdown_result="<option value=\"\">- Select a GDB -</option>\n\n";
+        $gdbQuery="SELECT distinct ID, DBname, Status FROM Genomes.xGDB_Log where (Status = 'Development' OR Status = 'Locked') order by ID";
+        $get_gdb = $gdbQuery;
+        $check_get_gdb = mysql_query($get_gdb);
+        $ID="";
+        $DBname="";
+        $Status="";
+        $selected="";
+        while ($gdb_data = mysql_fetch_array($check_get_gdb)) {
+                $ID = $gdb_data['ID'];
+                $DBid = "GDB".substr(('00'.$ID), -3);
+                $selected=($DBid==$current)?' selected="\"selected\"" ':'';
+                $DBname = $gdb_data['DBname'];  
+                $DBname = substr($DBname, 0, 30); //truncate long GDB name to fit better on page
+                
+                $Status = $gdb_data['Status'];  
+                $Stat = substr($Status, 0, 3);
+                $gdb_dropdown_result.= "<option $selected value=\"$ID\">$DBid (${Stat}) $DBname</option>\n\n";
+            }   
+            
+            return $gdb_dropdown_result;
 }
 
 /* uid 
@@ -71,45 +71,45 @@ return $job_name_stripped;
 */
 //build dropdown of Jobs  with date and type. (passes username from session)
 
-	function jobs_dropdown($username, $type){
-	
-		switch ($type) 
-		{
-	case "status":
-		$limit = "";
-		break;
-	case "output":
-		$limit = " AND status!=\"PENDING\"";
-		break;
-	case "terminate":
-		$limit = " AND job_end_time IS NULL AND status!=\"DELETED\"";
-		}
-	
-		$jobs_dropdown_result="<option value=\"\">- Select a job (most recent first) -</option>\n\n";
-		$jobsQuery="SELECT * FROM Admin.jobs where user=\"$username\" $limit order by job_submitted_time DESC";
-		$get_jobs = $jobsQuery;
-		$check_get_jobs = mysql_query($get_jobs);
-		$job_id="";
-		$DBname="";
-		$Status="";
-		$selected="";
-		$n=0;
-		while ($jobs_data = mysql_fetch_array($check_get_jobs)) {
-		        $n=$n+1;
-				$job_id = $jobs_data['job_id'];
-				$job_id_trimmed=ltrim(substr($job_id, 0, 16), '0');
-				$job_name = $jobs_data['job_name'];
-				$job_name_display=substr($job_name, 0, 15);
-				$job_submitted_time = $jobs_data['job_submitted_time'];
-				$status=$jobs_data['status'];
-				$uid=$jobs_data['uid'];
-				$seq_type = $jobs_data['seq_type'];	
-				$input_file_size = $jobs_data['input_file_size'];					
-				$genome_file_size = $jobs_data['genome_file_size'];				
-				$jobs_dropdown_result.= "<option value=\"${job_id}\">$uid. job-$job_id_trimmed: $job_name_display... ($status) - $job_submitted_time   </option>\n\n";
-			}	
-			
-			return $jobs_dropdown_result;
+    function jobs_dropdown($username, $type){
+    
+        switch ($type) 
+        {
+    case "status":
+        $limit = "";
+        break;
+    case "output":
+        $limit = " AND status!=\"PENDING\"";
+        break;
+    case "terminate":
+        $limit = " AND job_end_time IS NULL AND status!=\"DELETED\"";
+        }
+    
+        $jobs_dropdown_result="<option value=\"\">- Select a job (most recent first) -</option>\n\n";
+        $jobsQuery="SELECT * FROM Admin.jobs where user=\"$username\" $limit order by job_submitted_time DESC";
+        $get_jobs = $jobsQuery;
+        $check_get_jobs = mysql_query($get_jobs);
+        $job_id="";
+        $DBname="";
+        $Status="";
+        $selected="";
+        $n=0;
+        while ($jobs_data = mysql_fetch_array($check_get_jobs)) {
+                $n=$n+1;
+                $job_id = $jobs_data['job_id'];
+                $job_id_trimmed=ltrim(substr($job_id, 0, 16), '0');
+                $job_name = $jobs_data['job_name'];
+                $job_name_display=substr($job_name, 0, 15);
+                $job_submitted_time = $jobs_data['job_submitted_time'];
+                $status=$jobs_data['status'];
+                $uid=$jobs_data['uid'];
+                $seq_type = $jobs_data['seq_type']; 
+                $input_file_size = $jobs_data['input_file_size'];                   
+                $genome_file_size = $jobs_data['genome_file_size'];             
+                $jobs_dropdown_result.= "<option value=\"${job_id}\">$uid. job-$job_id_trimmed: $job_name_display... ($status) - $job_submitted_time   </option>\n\n";
+            }   
+            
+            return $jobs_dropdown_result;
 }
 
 
@@ -141,10 +141,10 @@ function URLIsReal($url){ //from stackoverflow; works in initial tests but not u
     $intReturnCode = curl_getinfo($resURL, CURLINFO_HTTP_CODE); 
     curl_close ($resURL); 
     if ($intReturnCode != 200 && $intReturnCode != 302 && $intReturnCode != 304) { 
-    	return false;
-    	 }
-	return true;
-	}
+        return false;
+         }
+    return true;
+    }
 
 
 ### THIS SCRIPT WILL BE REFACTORED FOR JOBS
@@ -160,279 +160,279 @@ function create_input_list($input_dir, $class, $dbpass)
 //Uses sub-function validate_file_type($name) to check validation and insert validation styling. 
 //Returns an array with file list formatted, number of files, file size, and unformatted list.
 
-	$db = mysql_connect("localhost", "gdbuser", $dbpass);
-	if(!$db)
-	{
-		echo "Error: Could not connect to database!";
-		exit;
-	}
-	mysql_select_db("Genomes");
-	
+    $db = mysql_connect("localhost", "gdbuser", $dbpass);
+    if(!$db)
+    {
+        echo "Error: Could not connect to database!";
+        exit;
+    }
+    mysql_select_db("Genomes");
+    
 
 
-	$file_list2="";
-	$total_size=0;
-	$fileID="";
-#	$file_list =`ls -l $input_dir`; //
-	$file_list =`ls -l --time-style=long-iso $input_dir`; //
+    $file_list2="";
+    $total_size=0;
+    $fileID="";
+#   $file_list =`ls -l $input_dir`; //
+    $file_list =`ls -l --time-style=long-iso $input_dir`; //
 
-	//system ("chop $list");
-	$list = explode( "\n", $file_list ); //file list array
-	$n=0; //valid file count
-	# now make a version of the file path that can be assigned as an html id tag; escape all forward slashes since we are going to assign them as an html id tag
-	$escaped_path=str_replace("/", "\/", $input_dir);
-	if (count($list) < 100 ) #avoid huge directories.
-	{ 
-		foreach ( $list as $item )
-			{
-				$pattern = "/\s+/";
-				$replacement = " ";
-				$item = preg_replace($pattern, $replacement, $item);
-				if ( substr( $item, 0, 1 ) == "-" ) // identifies file (-rw-r--r-- etc) as opposed to directory (drwxrwxr-x etc.)
-				{
-					$vals = explode( " ", $item );
-					$filename = $vals[count($vals)-1];
-					
-					if(validate_file_type($filename, $class)!="")# We want to list ONLY one class of filenames in this directory, not ALL files.
-					{		
-						$time = $vals[count($vals)-2];
-						$year_month_day = $vals[count($vals)-3];
-						$size = $vals[count($vals)-4];
-					   $filestamp = "$filename:$size:${year_month_day}-$time"; # IMPORTANT: This format MUST be synchronized with FileStamp in /xGDBvm/scripts/xGDB_ValidateFiles.sh
-					   $valid="";
-						   $entries="";
-						   $file_info_icon="information.png"; // This icon communicates validation status (by color) and is a click target for opening validation dialog box
-						 if($get_entry="SELECT Valid, EntryCount FROM Datafiles where FileStamp='$filestamp'")
-							 { 
-							 $mysql_get_entry = mysql_query($get_entry); 
-							 while($result_get_entry = mysql_fetch_array($mysql_get_entry)){
-							   $valid=$result_get_entry[0]; # T F or NULL
-							   $entries=$result_get_entry[1]; # number of entries
-							 }
-						}
-						$valid_style="filenoteval"; # default; blue
-						if($valid=="T")
-						{
-						$file_info_icon="information_green.png";
-						$valid_style="filevalid";
-						$v=$v+1;
-						}
-						elseif($valid=="F")
-						{
-						$file_info_icon="information_red.png";
-						$valid_style="filenotvalid";
-						$iv=$iv+1;
-						}
+    //system ("chop $list");
+    $list = explode( "\n", $file_list ); //file list array
+    $n=0; //valid file count
+    # now make a version of the file path that can be assigned as an html id tag; escape all forward slashes since we are going to assign them as an html id tag
+    $escaped_path=str_replace("/", "\/", $input_dir);
+    if (count($list) < 100 ) #avoid huge directories.
+    { 
+        foreach ( $list as $item )
+            {
+                $pattern = "/\s+/";
+                $replacement = " ";
+                $item = preg_replace($pattern, $replacement, $item);
+                if ( substr( $item, 0, 1 ) == "-" ) // identifies file (-rw-r--r-- etc) as opposed to directory (drwxrwxr-x etc.)
+                {
+                    $vals = explode( " ", $item );
+                    $filename = $vals[count($vals)-1];
+                    
+                    if(validate_file_type($filename, $class)!="")# We want to list ONLY one class of filenames in this directory, not ALL files.
+                    {       
+                        $time = $vals[count($vals)-2];
+                        $year_month_day = $vals[count($vals)-3];
+                        $size = $vals[count($vals)-4];
+                       $filestamp = "$filename:$size:${year_month_day}-$time"; # IMPORTANT: This format MUST be synchronized with FileStamp in /xGDBvm/scripts/xGDB_ValidateFiles.sh
+                       $valid="";
+                           $entries="";
+                           $file_info_icon="information.png"; // This icon communicates validation status (by color) and is a click target for opening validation dialog box
+                         if($get_entry="SELECT Valid, EntryCount FROM Datafiles where FileStamp='$filestamp'")
+                             { 
+                             $mysql_get_entry = mysql_query($get_entry); 
+                             while($result_get_entry = mysql_fetch_array($mysql_get_entry)){
+                               $valid=$result_get_entry[0]; # T F or NULL
+                               $entries=$result_get_entry[1]; # number of entries
+                             }
+                        }
+                        $valid_style="filenoteval"; # default; blue
+                        if($valid=="T")
+                        {
+                        $file_info_icon="information_green.png";
+                        $valid_style="filevalid";
+                        $v=$v+1;
+                        }
+                        elseif($valid=="F")
+                        {
+                        $file_info_icon="information_red.png";
+                        $valid_style="filenotvalid";
+                        $iv=$iv+1;
+                        }
 
 ##### Build more markup including escaped filepath and validation icons.  #####
 
-						$filepath = $escaped_path."\/".$filename; // We use this as a unique ID tag (with escaped slashes) for opening a Jquery dialog.
+                        $filepath = $escaped_path."\/".$filename; // We use this as a unique ID tag (with escaped slashes) for opening a Jquery dialog.
 
-						$info_icon_styled=   # for Jquery function
-						   "
-						      <span id=\"$filepath\" class=\"validatefile-button\" title=\"$filestamp\">
-						         <img class=\"nudge3\" src=\"/XGDB/images/$file_info_icon\" />
-						      </span>
-						   "
-						   ;
+                        $info_icon_styled=   # for Jquery function
+                           "
+                              <span id=\"$filepath\" class=\"validatefile-button\" title=\"$filestamp\">
+                                 <img class=\"nudge3\" src=\"/XGDB/images/$file_info_icon\" />
+                              </span>
+                           "
+                           ;
 ##### For GeneSeqer jobs we need to know the Fasta header (defline) type; get this and create a GSQ parameter to pass in the form submission #####
 
-						$file_path_name="${input_dir}/${filename}";
-						$fasta_header_type=fasta_header_type($file_path_name, $valid_style);
-						$fasta_type=$fasta_header_type[0];
-						$GSQparam=$fasta_header_type[1];
-						
-						
-						$n=$n+1; # To list all files in directory, not just valid ones, move right angle bracket from below to this line.
-						$filename_type = validate_file_type($filename, $class);
-						$filename_type_styled="<span class=\"$valid_style\">${filename_type}:</span>";
-						$filename_styled="<span class=\"$valid_style italic\">$filename</span>";
-						$filename_display = $filename_type_styled."  ".$filename_styled.$info_icon_styled." (".$fasta_type.")".$list_header_line_styled; # see below; next function. 
-						
+                        $file_path_name="${input_dir}/${filename}";
+                        $fasta_header_type=fasta_header_type($file_path_name, $valid_style);
+                        $fasta_type=$fasta_header_type[0];
+                        $GSQparam=$fasta_header_type[1];
+                        
+                        
+                        $n=$n+1; # To list all files in directory, not just valid ones, move right angle bracket from below to this line.
+                        $filename_type = validate_file_type($filename, $class);
+                        $filename_type_styled="<span class=\"$valid_style\">${filename_type}:</span>";
+                        $filename_styled="<span class=\"$valid_style italic\">$filename</span>";
+                        $filename_display = $filename_type_styled."  ".$filename_styled.$info_icon_styled." (".$fasta_type.")".$list_header_line_styled; # see below; next function. 
+                        
 ##### Calculate size in a reasonable numeric range #####
-						$total_size = $total_size + $size;
-						$unit = 0;  //0: bytes, 1:KB, 2: MB, 3: GB
-						while ($size > 1024 && $unit < 4)
-							{
-								$size = round($size / 1024,1);
-								$unit++;
-							}			
+                        $total_size = $total_size + $size;
+                        $unit = 0;  //0: bytes, 1:KB, 2: MB, 3: GB
+                        while ($size > 1024 && $unit < 4)
+                            {
+                                $size = round($size / 1024,1);
+                                $unit++;
+                            }           
 ##### Continue building the file 'list item' core: filename, validation icon, date and time / size /  #####
 
-				     	$file_list2.= "
-				     	<li class='smallerfont'>
-				     	   $filename_display / $size";
+                        $file_list2.= "
+                        <li class='smallerfont'>
+                           $filename_display / $size";
 
 ##### If file has been validated, # of entries is available from the MySQL query. Add this here at end of line if available. #####
-				     	   
-						$entries_styled=(empty($entries))?"":
-						"<span style=\"color:#00A592\"> 
-						    $entries entries
-						</span>";
-						
+                           
+                        $entries_styled=(empty($entries))?"":
+                        "<span style=\"color:#00A592\"> 
+                            $entries entries
+                        </span>";
+                        
 ##### Determine unit for display and compute absolute size in order to get cumulative total #####
-	
-						if($unit == 0) {$file_list2.= " bytes"; $units="bytes"; $abs_size = $size;}
-						if($unit == 1) {$file_list2.= " KB"; $units="KB"; $abs_size  = $size/.001;}
-						if($unit == 2) {$file_list2.= " MB"; $units="MB"; $abs_size = $size/.0000001;}
-						if($unit == 3) {$file_list2.= " GB"; $units="GB"; $abs_size =  $size/.0000000001;}
-						
+    
+                        if($unit == 0) {$file_list2.= " bytes"; $units="bytes"; $abs_size = $size;}
+                        if($unit == 1) {$file_list2.= " KB"; $units="KB"; $abs_size  = $size/.001;}
+                        if($unit == 2) {$file_list2.= " MB"; $units="MB"; $abs_size = $size/.0000001;}
+                        if($unit == 3) {$file_list2.= " GB"; $units="GB"; $abs_size =  $size/.0000000001;}
+                        
 ##### Finish display with the size units and list end #####
 
-						$file_list2.=" / ".$entries_styled."</li>";
-					}
-				}
-			}
-		}
+                        $file_list2.=" / ".$entries_styled."</li>";
+                    }
+                }
+            }
+        }
     $total_size_display=convert_bytes($total_size, 1);
-	if($n<1)
-		{
-		$class="smallerfont warning";
-		}
-		else
-		{
-		$class="smallerfont checked";
-		}
-	$file_list1="
-		<span class=\"plaintext largerfont bold\">
-			$input_dir 
-		</span>
-		<span class=\"normalfont\">
-			$valid_count_display $invalid_count_display $noteval_count_display
-		</span>";
-	$file_list1.="
-	<ul class='bullet1 indent2'>	";
-	
-	$file_list3="</ul>";
+    if($n<1)
+        {
+        $class="smallerfont warning";
+        }
+        else
+        {
+        $class="smallerfont checked";
+        }
+    $file_list1="
+        <span class=\"plaintext largerfont bold\">
+            $input_dir 
+        </span>
+        <span class=\"normalfont\">
+            $valid_count_display $invalid_count_display $noteval_count_display
+        </span>";
+    $file_list1.="
+    <ul class='bullet1 indent2'>    ";
+    
+    $file_list3="</ul>";
 
 ##### Assemble the pieces of the header and list  #####
 
-	$file_list_formatted = $file_list1.$file_list2.$file_list3;
-	
-	return array($file_list_formatted, $n, $total_size, $file_list); //$total_size in MB; we return $n in case we want to validate based on valid files
+    $file_list_formatted = $file_list1.$file_list2.$file_list3;
+    
+    return array($file_list_formatted, $n, $total_size, $file_list); //$total_size in MB; we return $n in case we want to validate based on valid files
 
 }
 
 
 ## The function below is called by create_input_list (above); matches file of name $name with standardized suffix according to $class (gdna or transcript) and returns human-readable interpretation (if any) with validation styling
 function validate_file_type($name, $class) 
-	{
-	$types="";
-	if($class=="transcript")
-		{
-	                $types = array
+    {
+    $types="";
+    if($class=="transcript")
+        {
+                    $types = array
                 (
 
                         "est.fa"   => "ESTs",
                         "cdna.fa"  => "cDNAs",
                         "tsa.fa"   => "transcript assemblies",
-           		);
-		}
-		elseif($class=="gdna")
-		{
-	                $types = array
+                );
+        }
+        elseif($class=="gdna")
+        {
+                    $types = array
                 (
-		            	"gdna.fa"  => "genomic DNA",
-				);
-			
-		}
-		elseif($class=="est")
-		{
-	                $types = array
+                        "gdna.fa"  => "genomic DNA",
+                );
+            
+        }
+        elseif($class=="est")
+        {
+                    $types = array
                 (
-		            	"est.fa"  => "ESTs",
-				);
-			
-		}		
-		elseif($class=="cdna")
-		{
-	                $types = array
+                        "est.fa"  => "ESTs",
+                );
+            
+        }       
+        elseif($class=="cdna")
+        {
+                    $types = array
                 (
-		            	"cdna.fa"  => "cDNAs",
-				);
-			
-		}
-		elseif($class=="tsa")
-		{
-	                $types = array
+                        "cdna.fa"  => "cDNAs",
+                );
+            
+        }
+        elseif($class=="tsa")
+        {
+                    $types = array
                 (
-		            	"tsa.fa"  => "TSAs",
-				);
-			
-		}
-		elseif($class=="protein" || $class=="prot")
-		{
-	                $types = array
+                        "tsa.fa"  => "TSAs",
+                );
+            
+        }
+        elseif($class=="protein" || $class=="prot")
+        {
+                    $types = array
                 (
-		            	"prot.fa"  => "proteins",
-				);
-			
-		}
-		
-		if($types!="")
-			{
-		
-				foreach($types as $ext => $type)
-				{
-			$test = "/\S*".$ext."$/i";
-						if(preg_match($test, $name, $match))
-						{
-								return $type;
-						}
-				}
-			}
-			else
-			{
-		return "";
-			}
-	}
+                        "prot.fa"  => "proteins",
+                );
+            
+        }
+        
+        if($types!="")
+            {
+        
+                foreach($types as $ext => $type)
+                {
+            $test = "/\S*".$ext."$/i";
+                        if(preg_match($test, $name, $match))
+                        {
+                                return $type;
+                        }
+                }
+            }
+            else
+            {
+        return "";
+            }
+    }
 
 
 
 #########################
 #  Fasta header type    #
-#########################	
+#########################   
 
 function fasta_header_type($file_path_name, $class){ //file_path_name is path/filename; class is gdna, transcript, protein.
 $header=`head -1 $file_path_name`;
 $genbank_pattern='/^>gi\|\d+/';
 $simple_pattern='/^>\S+/';
 if(preg_match($genbank_pattern, $header))
-	{
-	$type="GenBank";
-	$GSQparam=($class=="gdna")?"l":"d";
-	}
-	elseif(preg_match($simple_pattern, $header))
-	{
-	$type="ID only";
-	$GSQparam=($class=="gdna")?"L":"D";
-	}
-	else
-	{
-	$type="Unknown";
-	$GSQparam="";
-	}
-	return array($type, $GSQparam);
+    {
+    $type="GenBank";
+    $GSQparam=($class=="gdna")?"l":"d";
+    }
+    elseif(preg_match($simple_pattern, $header))
+    {
+    $type="ID only";
+    $GSQparam=($class=="gdna")?"L":"D";
+    }
+    else
+    {
+    $type="Unknown";
+    $GSQparam="";
+    }
+    return array($type, $GSQparam);
 }
 
 
 #####################
 #  Volume Checks    #
-#####################	
+#####################   
 
 function df_available($dir)
-	{ //we want display available space and directory list in the specified volume (this function also found under /xGDBvm/XGDB/conf/conf_functions.inc.php)
+    { //we want display available space and directory list in the specified volume (this function also found under /xGDBvm/XGDB/conf/conf_functions.inc.php)
 
-		$df =`df ${dir}`; #
-				$avail_match = "/.*\s*(\S+?)\s+(\d+?)\s+(\d+?)\s+(\d+?)\s+.*(\/.*)$/"; # last directory (non-greedy) 
-				preg_match( $avail_match, $df, $matches);
-				
-				$filesys=$matches[1];
-				$avail=$matches[4];
-				$mount=$matches[5];
-				
-	return array($filesys, $avail, $mount);
-	}
+        $df =`df ${dir}`; #
+                $avail_match = "/.*\s*(\S+?)\s+(\d+?)\s+(\d+?)\s+(\d+?)\s+.*(\/.*)$/"; # last directory (non-greedy) 
+                preg_match( $avail_match, $df, $matches);
+                
+                $filesys=$matches[1];
+                $avail=$matches[4];
+                $mount=$matches[5];
+                
+    return array($filesys, $avail, $mount);
+    }
 
 
 #######################
@@ -443,12 +443,12 @@ function df_available($dir)
 function validate_dir($dir, $target, $description, $present, $absent) //$dir is the containing dir; $target is the dir whose presence/absence we are testing; others are tags
         {
         $result=$absent; //assume the worst
-		$d_list =`ls -a ${dir}`; #All files in data directory
-        $d_array = preg_split('/\s+/', $d_list);	//split list by spaces into an array
-		if (count($d_array) < 500 ) //safety measure.
-			{
-			foreach ( $d_array as $d_item ) // go through all subdirs and mark $present only if match.
-					{
+        $d_list =`ls -a ${dir}`; #All files in data directory
+        $d_array = preg_split('/\s+/', $d_list);    //split list by spaces into an array
+        if (count($d_array) < 500 ) //safety measure.
+            {
+            foreach ( $d_array as $d_item ) // go through all subdirs and mark $present only if match.
+                    {
 
                         if($d_item == $target)
                         {
@@ -457,45 +457,45 @@ function validate_dir($dir, $target, $description, $present, $absent) //$dir is 
                     }
             } // define css markup class to cover the various syntaxes 
             if($result=="present")
-            	{
-            	 $class= "checked";
-				}
+                {
+                 $class= "checked";
+                }
             elseif($result=="missing" || $result=="not found"  )
-            	{
-            	 $class= "warning";
-				}
+                {
+                 $class= "warning";
+                }
             if($result=="installed")
-            	{
-            	 $class= "checked_installed";
-				}
+                {
+                 $class= "checked_installed";
+                }
             elseif($result=="not installed")
-            	{
-            	 $class= "warning";
-				}
+                {
+                 $class= "warning";
+                }
             elseif($result=="mounted")
-            	{
-            	 $class= "mounted";
-				}
+                {
+                 $class= "mounted";
+                }
             elseif($result=="not mounted")
-            	{
-            	 $class= "local";
-				}
+                {
+                 $class= "local";
+                }
 
             return array($result, $class);
-		}
+        }
 
 
 function calculate_scaffolds($input_path, $gsq_proc, $gth_proc) #input path is all that is needed to find gdna
 {
-	mysql_select_db("Genomes");
+    mysql_select_db("Genomes");
     $size=array();
-	$query="SELECT * from Datafiles where Path='$input_path' and SeqType='gdna'"; 
-	$get_query = mysql_query($query);
-	$gsq_split_available=$gsq_proc/8; # 8:1 threads (processes)
-	$gth_split_available=$gth_proc; # 1:1 with threads (processes)
-	while ($row = mysql_fetch_array($get_query))
-	{
-	   $sequence_count=$row['EntryCount'];
+    $query="SELECT * from Datafiles where Path='$input_path' and SeqType='gdna'"; 
+    $get_query = mysql_query($query);
+    $gsq_split_available=$gsq_proc/8; # 8:1 threads (processes)
+    $gth_split_available=$gth_proc; # 1:1 with threads (processes)
+    while ($row = mysql_fetch_array($get_query))
+    {
+       $sequence_count=$row['EntryCount'];
        $total_size =  $row['SizeTotal'];
        $size[1] =  $row['SizeLargest'];
        $size[2] =  $row['Size2'];
@@ -517,32 +517,32 @@ function calculate_scaffolds($input_path, $gsq_proc, $gth_proc) #input path is a
        $size[18] =  $row['Size18'];
        $size[19] =  $row['Size19'];
        $size[20] =  $row['Size20'];
-	}	
-	$n=0;
-	$cumulative_size=0;
-	global $large_scaffold_count;
+    }   
+    $n=0;
+    $cumulative_size=0;
+    global $large_scaffold_count;
     while ($n < 21 && !isset($large_scaffold_count)) # keep looping until we have counted all the large scaffolds.
     {
-		$n=$n+1;
-		$curr_size=$size[$n];
-		$cumulative_size=$cumulative_size + $curr_size;
-		if($curr_size==0)
-		{
-			$large_scaffold_count=$n-1; # set because we ran out of scaffolds before there was any drop in size
-		}
-		else
-		{
-			$m=($n==1)?$n:$n-1; #previous scaff
-			$prev_size=$size[$m];
-			$size_diff=$prev_size-$curr_size;
-			$ratio=$size_diff/$curr_size;
-			if($ratio>10)
-			{
-			   $large_scaffold_count=$n-1; # set because we ran out of large scaffolds and the remaining ones are much smaller
-			   
-			}
-		}
-	}
+        $n=$n+1;
+        $curr_size=$size[$n];
+        $cumulative_size=$cumulative_size + $curr_size;
+        if($curr_size==0)
+        {
+            $large_scaffold_count=$n-1; # set because we ran out of scaffolds before there was any drop in size
+        }
+        else
+        {
+            $m=($n==1)?$n:$n-1; #previous scaff
+            $prev_size=$size[$m];
+            $size_diff=$prev_size-$curr_size;
+            $ratio=$size_diff/$curr_size;
+            if($ratio>10)
+            {
+               $large_scaffold_count=$n-1; # set because we ran out of large scaffolds and the remaining ones are much smaller
+               
+            }
+        }
+    }
 $chunks=$n; # count of large individual scaffolds plus small 'remaineder' scaffolds catted together
 $remainder_size=$total_size - $cumulative_size; # what's left after you subtract out the large scaffolds
 $small_scaffold_count=$sequence_count - $large_scaffold_count;
@@ -578,22 +578,22 @@ return array($large_scaffold_count, $small_scaffold_count, $chunks, $remainder_s
 }
 
 function convert_bytes($size, $round) {
-	$unit = 0;  //0: bytes, 1: kilobytes, 2: megabytes, 3: gigabytes
-	$rel_size=0;
-	while ($size > 1024 && $unit < 4)
-		{
-			$size = round($size / 1024,$round);
-			$unit++;
-		}
+    $unit = 0;  //0: bytes, 1: kilobytes, 2: megabytes, 3: gigabytes
+    $rel_size=0;
+    while ($size > 1024 && $unit < 4)
+        {
+            $size = round($size / 1024,$round);
+            $unit++;
+        }
 
-	if($unit == 0) {$units = " bytes"; $abs_size = $size/1000000;}
-	if($unit == 1) {$units = " KB"; $abs_size  = $size/1000;}
-	if($unit == 2) {$units = " MB"; $abs_size = $size/1;}
-	if($unit == 3) {$units = " GB"; $abs_size =  $size/.001;}
-	$size_display="$size $units";
+    if($unit == 0) {$units = " bytes"; $abs_size = $size/1000000;}
+    if($unit == 1) {$units = " KB"; $abs_size  = $size/1000;}
+    if($unit == 2) {$units = " MB"; $abs_size = $size/1;}
+    if($unit == 3) {$units = " GB"; $abs_size =  $size/.001;}
+    $size_display="$size $units";
 
 return $size_display;
-			
+            
 }
 
 
@@ -606,40 +606,40 @@ function assign_job_stage($STATUS)
 // 3 = just finished running (status CLEANING_UP)
 // 4  = finished running but outputs not yet in place (status ARCHIVING, ARCHIVING_FINISHED)
 
-	$dead = array('FAILED', 'STOPPED', 'KILLED', 'ARCHIVING_FAILED'); // no output
-	$pre = array('SUBMITTED', 'PENDING', 'SUBMITTING', 'PROCESSING_INPUTS', 'STAGED', 'STAGING_JOB', 'STAGING_INPUTS', 'QUEUED'); // not yet running but on the way
-	$in = array('RUNNING'); // processing data
-	$out = array('CLEANING_UP'); // just finished processing data
-	$post = array('ARCHIVING', 'ARCHIVING_FINISHED'); // putting data in place
-	$done = array('FINISHED'); // done
-	if(in_array($STATUS,$dead))
-	{
-		$stage = 'dead';
-	}
-	elseif(in_array($STATUS,$pre))
-	{
-		$stage = 'pre';
-	}
-	elseif(in_array($STATUS,$in))
-	{
-		$stage = 'in';
-	}
-	elseif(in_array($STATUS,$out))
-	{
-		$stage = 'out';
-	}
-	elseif(in_array($STATUS,$post))
-	{
-		$stage = 'post';
-	}
-	elseif(in_array($STATUS,$done))
-	{
-		$stage = 'done';
-	}
-	else
-	{
-		$stage = $STATUS; // e.g. 'error'
-	}
+    $dead = array('FAILED', 'STOPPED', 'KILLED', 'ARCHIVING_FAILED'); // no output
+    $pre = array('SUBMITTED', 'PENDING', 'SUBMITTING', 'PROCESSING_INPUTS', 'STAGED', 'STAGING_JOB', 'STAGING_INPUTS', 'QUEUED'); // not yet running but on the way
+    $in = array('RUNNING'); // processing data
+    $out = array('CLEANING_UP'); // just finished processing data
+    $post = array('ARCHIVING', 'ARCHIVING_FINISHED'); // putting data in place
+    $done = array('FINISHED'); // done
+    if(in_array($STATUS,$dead))
+    {
+        $stage = 'dead';
+    }
+    elseif(in_array($STATUS,$pre))
+    {
+        $stage = 'pre';
+    }
+    elseif(in_array($STATUS,$in))
+    {
+        $stage = 'in';
+    }
+    elseif(in_array($STATUS,$out))
+    {
+        $stage = 'out';
+    }
+    elseif(in_array($STATUS,$post))
+    {
+        $stage = 'post';
+    }
+    elseif(in_array($STATUS,$done))
+    {
+        $stage = 'done';
+    }
+    else
+    {
+        $stage = $STATUS; // e.g. 'error'
+    }
 return $stage;
 }
 
@@ -647,22 +647,22 @@ return $stage;
 
 //build list of all available apps from Admin.apps
 
-	function list_apps(){
-		$apps_list="";
-		$query="SELECT * FROM Admin.apps order by platform, program, app_id";
-		$get_apps = mysql_query($query);
-		$item="";
-		while ($row = mysql_fetch_array($get_apps)) {
-				$app_id = $row['app_id'];
-				$program = $row['program'];
-				$version = $row['version'];
-				$platform = $row['platform'];
-				$nodes = $row['nodes'];
-				$proc_per_node = $row['proc_per_node'];
-				$apps_list.= "<li>$app_id ($platform)  ${nodes} x ${proc_per_node} </li>";
-			}	
-			
-			return $apps_list;
+    function list_apps(){
+        $apps_list="";
+        $query="SELECT * FROM Admin.apps order by platform, program, app_id";
+        $get_apps = mysql_query($query);
+        $item="";
+        while ($row = mysql_fetch_array($get_apps)) {
+                $app_id = $row['app_id'];
+                $program = $row['program'];
+                $version = $row['version'];
+                $platform = $row['platform'];
+                $nodes = $row['nodes'];
+                $proc_per_node = $row['proc_per_node'];
+                $apps_list.= "<li>$app_id ($platform)  ${nodes} x ${proc_per_node} </li>";
+            }   
+            
+            return $apps_list;
 }
 
 function apps_dropdown($program){
@@ -684,10 +684,77 @@ function apps_dropdown($program){
             $selected=($is_default=='Y')?' selected="\"selected\"" ':'';
             $default=($is_default=='Y')?' (default)':'';
             $app_dropdown_result.= "<option $selected value=\"$app_id\">$app_id ($platform) ${nodes} x ${proc_per_node} $default </option>\n\n";
-        }	
+        }   
          
         return $app_dropdown_result;
 }
 
+###################
+# AGAVE Settings  #
+###################
+# This becomes part of the Agave json string sent to Agave to configure status alerts for the VM and the user. 
+# modified 7-11-16 by JDuvick to include policy.
 
+function build_notifications_array($callbackUrl, $admin_email)
+{
+$notifications_array=($admin_email=="") # user hasn't set up an email alert
+?
+array
+       (
+            array
+            (
+               "url" =>  "$callbackUrl",
+               "event" => "*",
+               "persistent" => true,
+               "policy"=> array
+                  (
+                       "retryStrategy" => "IMMEDIATE",
+                       "retryLimit" => 20,
+                       "retryRate" => 5,
+                       "retryDelay" => 0,
+                       "saveOnFailure" => true
+                  )
+            )
+      )
+:
+array
+       (
+            array
+            (
+                 "url" => "$admin_email",
+                 "event" => "RUNNING",
+               "persistent" => false
+            ),
+            array
+            (
+               "url" => "$admin_email",
+               "event" =>  "FAILED",
+               "persistent" => false
+            ),
+            array
+            (
+               "url" => "$admin_email",
+               "event" =>  "FINISHED",
+               "persistent" => false
+            ),
+            array
+            (
+               "url" =>  "$callbackUrl",
+               "event" => "*",
+               "persistent" => true,
+               "policy"=> array
+                  (
+                   "retryStrategy" => "IMMEDIATE",
+                   "retryLimit" => 20,
+                   "retryRate" => 5,
+                   "retryDelay" => 0,
+                   "saveOnFailure" => true
+                  )
+            )
+      )
+;
+
+        
+return $notifications_array;
+}
 ?>

--- a/scripts/gsq_remote.php
+++ b/scripts/gsq_remote.php
@@ -1,5 +1,6 @@
 <?php
-#error_reporting(E_ALL ^ E_NOTICE);
+#error_reporting(E_ALL ^ E_NOTICE); 
+# Updated 7-11-2016 JDuvick
 
 include('sitedef.php');
 include_once('/xGDBvm/XGDB/phplib/db.inc.php'); #reads MySQL password from /xGDBvm/admin/dbpass
@@ -14,10 +15,10 @@ $global_DB2= 'Genomes';
 $dbpass=dbpass();
 $db = mysql_connect("localhost", "gdbuser", $dbpass);
 if(!$db)
-    {
-        echo "Error: Could not connect to database!";
-        exit;
-    }
+	{
+		echo "Error: Could not connect to database!";
+		exit;
+	}
 
 ## process arguments coming from shell script xGDB_Procedure.sh
 ## php $ScriptDIR/${prg}_remote.php $Id $PRG_username $PRG_token $gsq_server ${trn} $trn_type ## launches script that submits remote job using curl, and updates Genomes.xGDB_Log with status. $ID $username $refresh_token $gsq_server (e.g. 128.196.1.13) $type $trn_type (hard-coded for now)
@@ -36,41 +37,41 @@ error_log("\n gsq_remote.php get arguments: \n id=".$ID."\n username=".$username
 
 ####### Part I. $_GET parameters ########
 # Get ID and create DBid
-    $IDjustify="00".$ID;
-    $DBid = "GDB".substr($IDjustify, -3, 3);
+	$IDjustify="00".$ID;
+	$DBid = "GDB".substr($IDjustify, -3, 3);
 //debug
 echo "\n DBid=$DBid \n";
 
 # Use $type to populate additional output variables:
-global $gsq_job, $gsq_job_result, $transcript_dir;
-    switch ($type) 
-    {
-case "est":
-    $gsq_job="GSQ_Job_EST"; //column to update
-    $gsq_job_result="GSQ_Job_EST_Result"; //column to update
-    $transcript_dir="MRNADIR";
-    break;
-case "cdna":
-    $gsq_job="GSQ_Job_cDNA"; //column to update
-    $gsq_job_result="GSQ_Job_cDNA_Result"; //column to update
-    $transcript_dir="MRNADIR";
-    break;
-case "tsa": // i.e. put
-    $gsq_job="GSQ_Job_PUT"; //column to update
-    $gsq_job_result="GSQ_Job_PUT_Result"; //column to update
-    $transcript_dir="PUTDIR";
-    break;
-   }
+    global $gsq_job, $gsq_job_result, $transcript_dir;
+		switch ($type) 
+		{
+    case "est":
+        $gsq_job="GSQ_Job_EST"; //column to update
+        $gsq_job_result="GSQ_Job_EST_Result"; //column to update
+        $transcript_dir="MRNADIR";
+        break;
+    case "cdna":
+        $gsq_job="GSQ_Job_cDNA"; //column to update
+        $gsq_job_result="GSQ_Job_cDNA_Result"; //column to update
+        $transcript_dir="MRNADIR";
+        break;
+    case "tsa": // i.e. put
+        $gsq_job="GSQ_Job_PUT"; //column to update
+        $gsq_job_result="GSQ_Job_PUT_Result"; //column to update
+        $transcript_dir="PUTDIR";
+        break;
+       }
 # Use $format to create EstFormat for json:
-    switch ($format) 
-    {
-case "d":
-    $EstFormat = "d";
-    break;
-case "D":
-    $EstFormat = "D";
-    break;   
-   }
+		switch ($format) 
+		{
+    case "d":
+        $EstFormat = "d";
+        break;
+    case "D":
+        $EstFormat = "D";
+        break;   
+       }
 
 //debug
 echo "\n gsq_job=$gsq_job \n";
@@ -79,78 +80,77 @@ echo "\n gsq_job=$gsq_job \n";
 
 ## Get most recent Authorization URL from Admin.admin database;
 
-$auth_query="SELECT uid, auth_url, api_version from $global_DB1.admin where auth_url !='' order by uid DESC limit 0,1";
-$auth_result = mysql_query($auth_query);
-$auth=mysql_fetch_array($auth_result);
-$base_url=$auth['auth_url'];
-$api_version=$auth['api_version'];
+	$auth_query="SELECT uid, auth_url, api_version from $global_DB1.admin where auth_url !='' order by uid DESC limit 0,1";
+	$auth_result = mysql_query($auth_query);
+	$auth=mysql_fetch_array($auth_result);
+	$base_url=$auth['auth_url'];
+	$api_version=$auth['api_version'];
 
 /*## Get gsq_job_time (requestedTime), Processors, etc. from Admin database
 
-$gsq_query="SELECT uid, gsq_software, gsq_url, gsq_job_time, gsq_proc, gsq_proc_per_node, gsq_update from $global_DB1.admin where gsq_software !='' order by uid DESC limit 0,1";
-$get_gsq_record = mysql_query($gsq_query);
-$gsq=mysql_fetch_array($get_gsq_record);
-$appId=$gsq['gsq_software'];
-$HPC_Name=$gsq['gsq_url'];
-$processorCount=$gsq['gsq_proc'];
-$processorsPerNode=$gsq['gsq_proc_per_node'];
-$requestedTime=$gsq['gsq_job_time']; #requestedTime. NOTE: to debug error condition, comment out this variable. job submit will fail.
+	$gsq_query="SELECT uid, gsq_software, gsq_url, gsq_job_time, gsq_proc, gsq_proc_per_node, gsq_update from $global_DB1.admin where gsq_software !='' order by uid DESC limit 0,1";
+	$get_gsq_record = mysql_query($gsq_query);
+	$gsq=mysql_fetch_array($get_gsq_record);
+	$appId=$gsq['gsq_software'];
+	$HPC_Name=$gsq['gsq_url'];
+	$processorCount=$gsq['gsq_proc'];
+	$processorsPerNode=$gsq['gsq_proc_per_node'];
+	$requestedTime=$gsq['gsq_job_time']; #requestedTime. NOTE: to debug error condition, comment out this variable. job submit will fail.
 */
 
 ## Get processor info from database based on DEFAULT app_id (note: 'nodes' is not required, the app is pre-configured for node count, but we sent it anyway for informational purposes)
 
-$query="SELECT nodes, proc_per_node, memory_per_node, nodes, max_job_time, app_id, platform FROM $global_DB1.apps WHERE program ='GeneSeqer-MPI' AND  is_default ='Y'";
-$result = mysql_query($query);
-$row=mysql_fetch_array($result);
-$proc_per_node=$row['proc_per_node']; // should be 12 or 16
-$memory_per_node=$row['memory_per_node']; // default is '2' currently
-$nodes=$row['nodes'];
-$requested_time=$row['max_job_time']; // To do: make this user-configurable from within the view.php script
-$platform=$row['platform'];
-$app_id=$row['app_id'];
+	$query="SELECT nodes, proc_per_node, memory_per_node, nodes, max_job_time, app_id, platform FROM $global_DB1.apps WHERE program ='GeneSeqer-MPI' AND  is_default ='Y'";
+	$result = mysql_query($query);
+	$row=mysql_fetch_array($result);
+	$proc_per_node=$row['proc_per_node']; // should be 12 or 16
+	$memory_per_node=$row['memory_per_node']; // default is '2' currently
+	$nodes=$row['nodes'];
+	$requested_time=$row['max_job_time']; // To do: make this user-configurable from within the view.php script
+	$platform=$row['platform'];
+	$app_id=$row['app_id'];
 
 ## Get GeneSeqer parameters: Species_Model, Alignment_Stringency, Input_Data_Directory [input data path] for the GDB selected
-$param_query="SELECT Species_Model,Alignment_Stringency, Input_Data_Path from $global_DB2.xGDB_Log where ID= $ID";
-$get_param_record = $param_query;
-$check_get_param_record = mysql_query($get_param_record);
-$param_result = $check_get_param_record;
-$param=mysql_fetch_array($param_result);    
-$Species=$param['Species_Model']; #Species
-$Alignment_Stringency=$param['Alignment_Stringency']; #parse for wsize, minqHSP, minqHSPc
-$input_data_path=$param['Input_Data_Path']; #parse for input data size
+	$param_query="SELECT Species_Model,Alignment_Stringency, Input_Data_Path from $global_DB2.xGDB_Log where ID= $ID";
+	$get_param_record = $param_query;
+	$check_get_param_record = mysql_query($get_param_record);
+	$param_result = $check_get_param_record;
+	$param=mysql_fetch_array($param_result);	
+	$Species=$param['Species_Model']; #Species
+	$Alignment_Stringency=$param['Alignment_Stringency']; #parse for wsize, minqHSP, minqHSPc
+	$input_data_path=$param['Input_Data_Path']; #parse for input data size
 
 ## Get admin_email from Admin database
 
-$email_query="SELECT uid, admin_email FROM Admin.admin where admin_email !='' order by uid DESC limit 0,1";
-$get_email_record = $email_query;
-$check_get_email_record = mysql_query($get_email_record);
-$email_result = $check_get_email_record;
-$email=mysql_fetch_array($email_result);
-$admin_email=$email['admin_email']; 
+	$email_query="SELECT uid, admin_email FROM Admin.admin where admin_email !='' order by uid DESC limit 0,1";
+	$get_email_record = $email_query;
+	$check_get_email_record = mysql_query($get_email_record);
+	$email_result = $check_get_email_record;
+	$email=mysql_fetch_array($email_result);
+	$admin_email=$email['admin_email']; 
 
 ####### Part IIB. Other parameters and calculations ########
 
 ## Calculate file sizes (information only;  write to jobs database) based on original data locations
-$trans_array = create_input_list($input_data_path, $type, $dbpass); # calculate total file size - transcript (jobs_functions.inc.php)
-$gdna_array = create_input_list($input_data_path, "gdna", $dbpass); # calculate total file size - genome
-$input_file_size=$trans_array[2];
-$genome_file_size=$gdna_array[2];
+	$trans_array = create_input_list($input_data_path, $type, $dbpass); # calculate total file size - transcript (jobs_functions.inc.php)
+	$gdna_array = create_input_list($input_data_path, "gdna", $dbpass); # calculate total file size - genome
+	$input_file_size=$trans_array[2];
+	$genome_file_size=$gdna_array[2];
 
 ## Set other parameters
-$splitSize=$nodes; // for GeneSeqer-MPI, we distribute genome segments among available nodes (e.g. 3 nodes processing 12 chromosomes= 3-way split, or 4 chromosomes per node), and use individual processors on each node to calculate a fraction of the EST sequences. MPI then combines results at each node.
-$total_threads=$proc_per_node*$nodes;
-$archive=true; //debug, deposits output in /input/archive/jobs/
-$submitted =  date("Y-m-d-H-i-s");
-$job_name="${DBid}-gsq-pipeline-${submitted}";  //e.g. GDB001-GSQ-Pipeline-2015-03-01-04-22-44
+	$splitSize=$nodes; // for GeneSeqer-MPI, we distribute genome segments among available nodes (e.g. 3 nodes processing 12 chromosomes= 3-way split, or 4 chromosomes per node), and use individual processors on each node to calculate a fraction of the EST sequences. MPI then combines results at each node.
+	$total_threads=$proc_per_node*$nodes;
+	$archive=true; //debug, deposits output in /input/archive/jobs/
+	$submitted =  date("Y-m-d-H-i-s");
+	$job_name="${DBid}-gsq-pipeline-${submitted}";	//e.g. GDB001-GSQ-Pipeline-2015-03-01-04-22-44
 
 # Hard coded: maxnest, genomeFormat
 
-$maxnest="999999999";//for json
-$genomeFormat="L";//non-GenBank libfname -- for json
+	$maxnest="999999999";//for json
+	$genomeFormat="L";//non-GenBank libfname -- for json
 
 # Parse from parameter string: wsize, minqHSP, minqHSPc, Species
-switch ($Alignment_Stringency) 
-{
+	switch ($Alignment_Stringency) {
     case ($Alignment_Stringency == "Strict"):
         $parameters = "-x 30 -y 45 -z 60 -w 0.80";
         break;
@@ -160,294 +160,252 @@ switch ($Alignment_Stringency)
     case ($Alignment_Stringency == "Low"):
         $parameters = "-x 12 -y 12 -z 30 -w 0.80";
         break;
-}
-$param = explode(" ", $parameters);
-$wsize=$param[1]; // -x; for json
-$minqHSP=$param[3];// -y for json
-$minqHSPc=$param[5]; // -z  for json
-$minESTc=$param[7]; // -w  for json
+	}
+	$param = explode(" ", $parameters);
+	$wsize=$param[1]; // -x; for json
+	$minqHSP=$param[3];// -y for json
+	$minqHSPc=$param[5]; // -z  for json
+	$minESTc=$param[7]; // -w  for json
 
 
 ####### Part IIC. Set data paths and filenames for Curl ########
 
 ## Specify TEMPORARY user input data paths with user's iPlant DataStore home directory as base 
-$user_input_mrna_path="/${username}/${inputTopDir}tmp/${DBid}_hpc/$transcript_dir/"; //e.g."/username/xgdbvm/tmp/GDB001_hpc/MRNADIR/"
-$user_input_scaff_path="/${username}/${inputTopDir}tmp/${DBid}_hpc/SCFDIR/"; //e.g."/username/xgdbvm/tmp/GDB001_hpc/SCFDIR/"
+	$user_input_mrna_path="/${username}/${inputTopDir}tmp/${DBid}_hpc/$transcript_dir/"; //e.g."/username/xgdbvm/tmp/GDB001_hpc/MRNADIR/"
+	$user_input_scaff_path="/${username}/${inputTopDir}tmp/${DBid}_hpc/SCFDIR/"; //e.g."/username/xgdbvm/tmp/GDB001_hpc/SCFDIR/"
 
 ## Specify TEMPORARY output directory; the pipeline creates this directory and picks up remote-computed output data there.
-$user_output_data_path="/${username}${inputTopDir}${DBid}_hpc/GSQOUT/"; // e.g."/username/GDB001_hpc/GSQOUT/"  NOT USING THIS CURRENTLY. OUTPUT GOES TO /home/user/archive/jobs/
+	$user_output_data_path="/${username}${inputTopDir}${DBid}_hpc/GSQOUT/"; // e.g."/username/GDB001_hpc/GSQOUT/"  NOT USING THIS CURRENTLY. OUTPUT GOES TO /home/user/archive/jobs/
 
 # Construct input and output paths. NOTE: these are used by TACC so they are relative to iPlant Data Store user home page ($username)
 
-$estSeq="${user_input_mrna_path}${DBid}${type}.fa";  //for json; Input Transcript File, e.g. [DataStore]/username/GDB001_hpc/SCFDIR/GDB002est.fa [cdna tsa]
-$libfname="${user_input_scaff_path}${DBid}gdna.fa"; // for json; Input Genome File, e.g.  [DataStore]/username/GDB001_hpc/SCFDIR/GDB002gdna.fa  
-$outPutFile="${DBid}${type}.gsq"; // for json; e.g. GDB001est.gsq
-$outPutPath="$user_output_data_path"; //for json; e.g.  [DataStore]/username/GDB001_hpc/GSQOUT/
+	$estSeq="${user_input_mrna_path}${DBid}${type}.fa";  //for json; Input Transcript File, e.g. [DataStore]/username/GDB001_hpc/SCFDIR/GDB002est.fa [cdna tsa]
+	$libfname="${user_input_scaff_path}${DBid}gdna.fa"; // for json; Input Genome File, e.g.  [DataStore]/username/GDB001_hpc/SCFDIR/GDB002gdna.fa	
+	$outPutFile="${DBid}${type}.gsq"; // for json; e.g. GDB001est.gsq
+	$outPutPath="$user_output_data_path"; //for json; e.g.  [DataStore]/username/GDB001_hpc/GSQOUT/
 
 ## Calculate scaffold number for display (we use the sorted scaffolds in the temp directory)
-$scaffolds=calculate_scaffolds($user_input_scaff_path, $proc_per_node, $proc_per_node); # jobs_functions.inc.php
-$gsq_split=$scaffolds[4]; # this is for information purposes only, it is the split of segments we predict will be used 
+    $scaffolds=calculate_scaffolds($user_input_scaff_path, $proc_per_node, $proc_per_node); # jobs_functions.inc.php
+    $gsq_split=$scaffolds[4]; # this is for information purposes only, it is the split of segments we predict will be used 
 
-$large_scaffold_count=$scaffolds[0];
-$small_scaffold_count=$scaffolds[1];
-$total_scaffold_count=$large_scaffold_count + $small_scaffold_count;
+    $large_scaffold_count=$scaffolds[0];
+    $small_scaffold_count=$scaffolds[1];
+    $total_scaffold_count=$large_scaffold_count + $small_scaffold_count;
 
 
 ############## Part III. Refresh access_token for Agave API #############
 
-// A. First, get the OAuth App credentials for this user, VM:
+ // A. First, get the OAuth App credentials for this user, VM:
+ 
+    $handle = fopen("/xGDBvm/admin/auth", "r");
+    $auth_error="";        
 
-$handle = fopen("/xGDBvm/admin/auth", "r");
-$auth_error="";        
-
-if($handle)
-{
-    while (($line = fgets($handle)) !== false) 
+    if($handle)
     {
-        $pattern="/^".$username.":([A-Za-z0-9\_]+?):([A-Za-z0-9\_]+?)$/"; # e.g. newuser:hZ_z3f4Hf3CcgvGoMix0aksN4BOD6:UH758djfDF8sdmsi004wER
-        if(preg_match($pattern, $line, $matches))
+        while (($line = fgets($handle)) !== false) 
         {
-            $consumer_key=$matches[1];
-            $consumer_secret=$matches[2];
+            $pattern="/^".$username.":([A-Za-z0-9\_]+?):([A-Za-z0-9\_]+?)$/"; # e.g. newuser:hZ_z3f4Hf3CcgvGoMix0aksN4BOD6:UH758djfDF8sdmsi004wER
+            if(preg_match($pattern, $line, $matches))
+            {
+                $consumer_key=$matches[1];
+                $consumer_secret=$matches[2];
+            }
+        }
+        fclose($handle);
+        
+        if($consumer_key =="" || $consumer_secret == "")
+        {
+        $auth_error="The consumer_key or consumer_secret could not be read; ";
         }
     }
-    fclose($handle);
-    
-    if($consumer_key =="" || $consumer_secret == "")
+    else
     {
-    $auth_error="The consumer_key or consumer_secret could not be read; ";
+   		$auth_error="The /xGDBvm/admin/auth file for storing consumer_key and consumer_secret is missing; ";
     }
-}
-else
-{
-    $auth_error="The /xGDBvm/admin/auth file for storing consumer_key and consumer_secret is missing; ";
-}
 
 // B. Next, grab the cached refresh_token and GET A NEW ACCESS_TOKEN using 'refresh' command for OAuth. We also cache the new refresh token.
 
-if($auth_error=="")
-{
-// Run 'get_refresh_token' function (login_functions.inc.php) From flat file /xGDBvm/admin/refresh
-    $refresh_token=get_refresh_token($username); // 
-// Run 'refresh' function (login_functions.inc.php) Uses refresh_token to re-authenticate user and retrieve new OAuth2 access_token for our Curl job request. It also retrieves and stores a new refresh_token (replacing the old one)
-    $auth_array=refresh($consumer_key, $consumer_secret, $refresh_token, $base_url, $username);  // 
-    # returns  array($http_code, $access_token, $refresh_token, $expires, $issued, $lifespan, $response);
-    $old_refresh_token=$refresh_token; // debug purposes
-    $http_code=$auth_array[0]; // 200 = success; 400=malformed request;  401 = bad username/password 0 = no repsonse (bad URL)
-    $access_token=$auth_array[1]; # this will give us access via Curl to the Agave API
-    $refresh_token=$auth_array[2]; # this is a brand-new refresh_token (it .
+    if($auth_error=="")
+    {
+    // Run 'get_refresh_token' function (login_functions.inc.php) From flat file /xGDBvm/admin/refresh
+        $refresh_token=get_refresh_token($username); // 
+    // Run 'refresh' function (login_functions.inc.php) Uses refresh_token to re-authenticate user and retrieve new OAuth2 access_token for our Curl job request. It also retrieves and stores a new refresh_token (replacing the old one)
+        $auth_array=refresh($consumer_key, $consumer_secret, $refresh_token, $base_url, $username);  // 
+        # returns  array($http_code, $access_token, $refresh_token, $expires, $issued, $lifespan, $response);
+        $old_refresh_token=$refresh_token; // debug purposes
+		$http_code=$auth_array[0]; // 200 = success; 400=malformed request;  401 = bad username/password 0 = no repsonse (bad URL)
+	    $access_token=$auth_array[1]; # this will give us access via Curl to the Agave API
+	    $refresh_token=$auth_array[2]; # this is a brand-new refresh_token (it .
 
-error_log("\n Authentication returned http_code $http_code.\n"); #  
+	error_log("\n Authentication returned http_code $http_code.\n"); #  
 
 // DEBUG ONLY; COMMENT OUT OTHERWISE
-#error_log("\n \n http_code :".$http_code." \n \n consumer_key :".$consumer_key."\n \n consumer_secret :".$consumer_secret."\n \n new access_token :".$access_token."\n\n new refresh_token:".$refresh_token."\n \n old refresh_token:".$old_refresh_token."\n\n"); 
+	#error_log("\n \n http_code :".$http_code." \n \n consumer_key :".$consumer_key."\n \n consumer_secret :".$consumer_secret."\n \n new access_token :".$access_token."\n\n new refresh_token:".$refresh_token."\n \n old refresh_token:".$old_refresh_token."\n\n"); 
 // END DEBUG ONLY
 
-}
-else
-{
-    $auth_error .= "No access token could be obtained; ";
-}
+    }
+    else
+	{
+		$auth_error .= "No access token could be obtained; ";
+	}
 if ($auth_error!="")
 {
-    error_log("\n Authentication FAILED - ".$auth_error."\n");
+error_log("\n Authentication FAILED - ".$auth_error."\n");
 }
 else
 {
 
 ############## Part IV. Populate CURL object and submit #############
 
-    # DEBUG ONLY! COMMENT OUT WHEN LIVE
-    error_log("\n Authentication succeeded. cURL submitted to URL: \n \n refresh_token=".$refresh_token."\n \n access_token=".$access_token."\n \n username=".$username."\n"); # DEBUG ONLY! COMMENT OUT WHEN LIVE
+	# DEBUG ONLY! COMMENT OUT WHEN LIVE
+	error_log("\n Authentication succeeded. cURL submitted to URL: \n \n refresh_token=".$refresh_token."\n \n access_token=".$access_token."\n \n username=".$username."\n"); # DEBUG ONLY! COMMENT OUT WHEN LIVE
 
-    //Create a php curl object  
-        $ch = curl_init();
-    
-    //construct the url for this app
+	//Create a php curl object  
+		$ch = curl_init();
+	
+	//construct the url for this app
 
-        $job_url="${base_url}/jobs/${api_version}"; # from Admin.admin database
+		$job_url="${base_url}/jobs/${api_version}"; # from Admin.admin database
 
-    //CALLBACK URL - see http://agaveapi.co/notifications-and-events/
-        $nonce = hash('sha512', mt_rand()*time()); # insure callback identity
-        $callbackUrl="https://".$server."/XGDB/jobs/webhook.php?nonce=".$nonce."&ID=".$ID."&type=$type&job_id=\${JOB_ID}&status=\${JOB_STATUS}&error=\${JOB_ERROR}"; // this script will update status in MySQL tables monitored by the pipeline
+	//CALLBACK URL - see http://agaveapi.co/notifications-and-events/
+		$nonce = hash('sha512', mt_rand()*time()); # insure callback identity
+	    $callbackUrl="https://".$server."/XGDB/jobs/webhook.php?nonce=".$nonce."&ID=".$ID."&type=$type&job_id=\${JOB_ID}&status=\${JOB_STATUS}&error=\${JOB_ERROR}"; // this script will update status in MySQL tables monitored by the pipeline
 
-    //Setting post array that we will jsonify. See http://agaveapi.co/live-docs/#!/jobs/submit_post_1
+	//Setting post array that we will jsonify. See http://agaveapi.co/live-docs/#!/jobs/submit_post_1
 
-    //If amin_email missing, don't include email webhooks.
+	//If amin_email missing, don't include email webhooks.
 
-    $notifications=($admin_email=="")
-    ?
-    array
-           (
-                array(
-                   "url" =>  "$callbackUrl",
-                   "event" => "*",
-                   "persistent" => true
-                )
-            )
-    :
-    array
-           (
-               array(
-                     "url" => "$admin_email",
-                     "event" => "RUNNING",
-                   "persistent" => false
-                ),
-                array(
-                   "url" => "$admin_email",
-                   "event" =>  "FAILED",
-                   "persistent" => false
-                ),
-                array(
-                   "url" => "$admin_email",
-                   "event" =>  "FINISHED",
-                   "persistent" => false
-                ),
-                array(
-                   "url" =>  "$callbackUrl",
-                   "event" => "*",
-                   "persistent" => true
-                )
-            )
-    ;
-    //create array
-        $job_data = array
-        (
-           "name" => "$job_name",
-           "appId" => "$app_id",
-           "nodeCount"=>$nodes,
-           "processorsPerNode" =>$proc_per_node,
-           "maxRunTime" =>"$requested_time",
-           "memoryPerNode" =>$memory_per_node,
-           "archive" =>$archive,
-           "archiveSystem" =>"data.iplantcollaborative.org",
-           "notifications" =>$notifications,
-            "inputs" => array
-            (
-               "libfname" => "$libfname",
+$notifications = build_notifications_array($callbackUrl, $admin_email); # see jobs_functions.inc.php; an array for alerts to the VM / user (if admin email configured)
+
+	//create array
+		$job_data = array
+		(
+		   "name" => "$job_name",
+		   "appId" => "$app_id",
+		   "nodeCount"=>$nodes,
+		   "processorsPerNode" =>$proc_per_node,
+		   "maxRunTime" =>"$requested_time",
+		   "memoryPerNode" =>$memory_per_node,
+		   "archive" =>$archive,
+		   "archiveSystem" =>"data.iplantcollaborative.org",
+		   "notifications" =>$notifications,
+			"inputs" => array
+			(
+			   "libfname" => "$libfname",
                 "estSeq" => "$estSeq"
-            ),
-            "parameters" => array
-            (
-               "splitSize" =>"$splitSize",
-               "outPutFile" =>"$outPutFile",
-               "outPutPath" =>"$outPutPath",
-               "EstFormat" => "$EstFormat",
-               "genomeFormat" => "$genomeFormat",
-               "Species" => "$Species",
-               "wsize" => "$wsize",
-               "minqHSP" => "$minqHSP",
-               "minqHSPc" => "$minqHSPc",
-               "minqHSPc" => "$minqHSPc",
-               "minESTc" => "$minESTc",
-               "maxnest" => "$maxnest"
-           )
-        );
+			),
+			"parameters" => array
+			(
+			   "splitSize" =>"$splitSize",
+			   "outPutFile" =>"$outPutFile",
+			   "outPutPath" =>"$outPutPath",
+			   "EstFormat" => "$EstFormat",
+			   "genomeFormat" => "$genomeFormat",
+			   "Species" => "$Species",
+			   "wsize" => "$wsize",
+			   "minqHSP" => "$minqHSP",
+			   "minqHSPc" => "$minqHSPc",
+			   "minqHSPc" => "$minqHSPc",
+			   "minESTc" => "$minESTc",
+			   "maxnest" => "$maxnest"
+		   )
+		);
 
-    // Encode data array as JSON object and strip escaped slashes.  
-        $postField = str_replace("\/", "/", json_encode($job_data));
+	// Encode data array as JSON object and strip escaped slashes.	
+		$postField = str_replace("\/", "/", json_encode($job_data));
 
-    //Set php curl options including authorization
-        curl_setopt($ch, CURLOPT_URL,$job_url);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $postField );
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array( "Content-Type:application/json", "Authorization: Bearer  $access_token"));
-    //Set up a loop to retry submission every (30 seconds) if not successful, up to (5) attempts.
-     $attempts=0;
-     $max_attempts=5;
-     for ($i = 1; $i <= $max_attempts; $i++)
-     {
-    //Execute the php curl and grab the response
-        $response = curl_exec($ch);
-        $resultStatus = curl_getinfo($ch);
-    
-        //Turn the response into json which php can manipulate 
-        $handled_json = json_decode($response,true);
+	//Set php curl options including authorization
+		curl_setopt($ch, CURLOPT_URL,$job_url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $postField );
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array( "Content-Type:application/json", "Authorization: Bearer  $access_token"));
 
-        //If the php curl was successful, display the results, if not, print failed results
+	//Execute the php curl and grab the response
+		$response = curl_exec($ch);
+		$resultStatus = curl_getinfo($ch);
+	
+		//Turn the response into json which php can manipulate 
+		$handled_json = json_decode($response,true);
 
-    //for information purposes, build the parameter string that GenomeThreader sees:
+		//If the php curl was successful, display the results, if not, print failed results
+
+	//for information purposes, build the parameter string that GenomeThreader sees:
         $parameters="-s $Species -$genomeFormat $libfname -$EstFormat $estSeq -x $wsize -y $minqHSP -z $minqHSPc -w $minESTc -m $maxnest -o $outPutPath$outPutFile ";
 
-    #/* comment out this block to debug
-    $http_code=$resultStatus['http_code'];
-    $attempts=$attempts+1;
-    if($http_code == 200 || $http_code == 201)
-    break;
-    sleep(30);
-    }
-    // After up to 5 tries, 
 
-    if($http_code == 200 || $http_code == 201)
-    {
-        $message=$handled_json['result']['message']; // status message
-        $job_id=$handled_json['result']['id']; // e.g 0001424105021858-5056a550b8-0001-007
-        $job_id_trimmed=ltrim(substr($job_id, 0, 16), '0'); // e.g. 0001424105021858
-        $job_id_rest=substr($job_id, 16, 20); // e.g. -5056a550b8-0001-007
-        $submit_time=$handled_json['result']['submitTime']; // from Agave
-        $submit_time_u=strtotime($submit_time);
-        $start_time=$handled_json['result']['startTime']; //from Agave  
-        $job_submitted_time=date("Y-m-d H:i:s"); // submitted by the VM. For now we are storing this value, not $submit_time
-        $job_submitted_time_u=strtotime($job_submitted_time);
-        $STATUS=$handled_json['result']['status']; // PENDING is the standard response if successful
-        $status=strtolower($STATUS); # for styling
-        $nodeCount=$handled_json['nodeCount'];
-        $archive_path=($STATUS=="PENDING")?"/${username}/archive/jobs/job-${job_id}/":"N/A";
-        $comment="$attempts attempts; ";
-        $comment.="${STATUS}: $submit_time | "; // This is the actual submit time returned by the server. Subsequent status updates will be concatenated here.
-        // Store job data in Admin.jobs database table.
+	#/* comment out this block to debug
+	$http_code=$resultStatus['http_code'];
+	
+	if($http_code == 200 || $http_code == 201)
+	{
+		$message=$handled_json['result']['message']; // status message
+		$job_id=$handled_json['result']['id']; // e.g 0001424105021858-5056a550b8-0001-007
+		$job_id_trimmed=ltrim(substr($job_id, 0, 16), '0'); // e.g. 0001424105021858
+		$job_id_rest=substr($job_id, 16, 20); // e.g. -5056a550b8-0001-007
+		$submit_time=$handled_json['result']['submitTime']; // from Agave
+		$submit_time_u=strtotime($submit_time);
+		$start_time=$handled_json['result']['startTime']; //from Agave	
+		$job_submitted_time=date("Y-m-d H:i:s"); // submitted by the VM. For now we are storing this value, not $submit_time
+		$job_submitted_time_u=strtotime($job_submitted_time);
+	    $STATUS=$handled_json['result']['status']; // PENDING is the standard response if successful
+		$status=strtolower($STATUS); # for styling
+		$nodeCount=$handled_json['nodeCount'];
+		$archive_path=($STATUS=="PENDING")?"/${username}/archive/jobs/job-${job_id}/":"N/A";
+        $comment="${STATUS}: $submit_time | "; // This is the actual submit time returned by the server. Subsequent status updates will be concatenated here.
+		// Store job data in Admin.jobs database table.
 
-        $statement="Insert into $global_DB1.jobs (nonce, job_id, job_name, status, db_id, job_type, program, softwareName, job_URL, HPC_name, user, admin_email, seq_type, genome_file_size, 
-        genome_segments, split_count, input_file_size, parameters, requested_time, processors, memory, comments, posted_data, server_response, job_submitted_time)
-        values  ('$nonce','$job_id', '$job_name', '$STATUS', $ID, 'Pipeline', 'GSQ', '$app_id', '$job_url', '$HPC_name', '$username', 
-        '$admin_email', '$type', '$genome_file_size', '$total_scaffold_count', '$splitSize', '$input_file_size', '$parameters', '$requested_time', '$proc_per_node', '$memory_per_node', '$comment', '$postField', '$response', '$job_submitted_time')"; 
-        $do_statement = mysql_query($statement);
-    
+		$statement="Insert into $global_DB1.jobs (nonce, job_id, job_name, status, db_id, job_type, program, softwareName, job_URL, HPC_name, user, admin_email, seq_type, genome_file_size, 
+		genome_segments, split_count, input_file_size, parameters, requested_time, processors, memory, comments, posted_data, server_response, job_submitted_time)
+		values  ('$nonce','$job_id', '$job_name', '$STATUS', $ID, 'Pipeline', 'GSQ', '$app_id', '$job_url', '$HPC_name', '$username', 
+		'$admin_email', '$type', '$genome_file_size', '$total_scaffold_count', '$splitSize', '$input_file_size', '$parameters', '$requested_time', '$proc_per_node', '$memory_per_node', '$comment', '$postField', '$response', '$job_submitted_time')"; 
+		$do_statement = mysql_query($statement);
+	
 # Report the outcome 
 
 error_log("\n gsq_remote.php cURL SUCCEEDED. Submitted to URL:".$job_url." \n postField=".$postField."\n parameters=".$parameters."\n status=".$STATUS."\n job_id=".$job_id."\n");
 
 
 # Create job_directory, unique identifier. This may be needed to retrieve output where remote HPC deposits in the user's archive directory e.g. archive/jobs/job-[job_id]/GDBnnn.gsq
-        $job_directory ="job-".$job_id; // combination of remote job ID and local job name. e.g. job-0001424449412643-5056a550b8-0001-007
+		$job_directory ="job-".$job_id; // combination of remote job ID and local job name. e.g. job-0001424449412643-5056a550b8-0001-007
+
 
 # write job_id and result (status) to xGDB_Log table. NOTE: this is NOT jobs table! The job_id is read by the pipeline script as a sign to proceed, and it also provides the name of the output directory.
 
-        $job_id_query = "update $global_DB2.xGDB_Log set $gsq_job = '$job_id', $gsq_job_result ='$STATUS' where ID=$ID"; # e.g. GSQ_Job_EST = 0001424449412643-5056a550b8-0001-007, GSQ_Job__EST_Result=PENDING
-        $job_id_update = mysql_query($job_id_query);  
+		$job_id_query = "update $global_DB2.xGDB_Log set $gsq_job = '$job_id', $gsq_job_result ='$STATUS' where ID=$ID"; # e.g. GSQ_Job_EST = 0001424449412643-5056a550b8-0001-007, GSQ_Job__EST_Result=PENDING
+		$job_id_update = mysql_query($job_id_query);  
 
-    } 
-    else
-    { //Curl submit failed
+	} 
+	else
+	{ //Curl submit failed
 
-         error_log("\n gsq_remote.php FAILED. cURL submitted to URL:".$job_url." http_code=".$http_code." \n \n postField=".$postField."\n \n parameters=".$parameters."\n \n message=".$message."\n \n response=".$response."\n \n");
-        
-        $STATUS="ERROR";
-        $status=$handled_json['status'];// error is the typical response (NOTE: this is different from $STATUS where a job has been successfully submitted)
-        $comment="$attempts attempts; ";
-        $comment.=$handled_json['message'];// Failed to submit job is the typical response
-    
+error_log("\n gsq_remote.php FAILED. cURL submitted to URL:".$job_url." http_code=".$http_code." \n \n postField=".$postField."\n \n parameters=".$parameters."\n \n message=".$message."\n \n response=".$response."\n \n");
+		
+		$STATUS="ERROR";
+		$status=$handled_json['status'];// error is the typical response (NOTE: this is different from $STATUS where a job has been successfully submitted)
+		$comment=$handled_json['message'];// Failed to submit job is the typical response
+	
 # Create job_name, a text identifier for failed job (no job ID assigned, so just use failure result, e.g. 'null')
-        $job_id ="error-".$job_name; // combination of 'null' and local job name. e.g. error-Q2Ejd-20130313-203456
+		$job_id ="error-".$job_name; // combination of 'null' and local job name. e.g. error-Q2Ejd-20130313-203456
 
-        $response_display = str_replace('>', ' ', (str_replace('>', ' ', $response))); // we will be displaying this in a table; it may be formatted
+$response_display = str_replace('>', ' ', (str_replace('>', ' ', $response))); // we will be displaying this in a table; it may be formatted
 
 # Store job data in Admin.jobs database table.
-        $statement="Insert into $global_DB1.jobs 
-        (job_id, job_name, status, db_id, job_type, program, softwareName, job_URL, HPC_name, user, admin_email, seq_type, genome_file_size, genome_segments, split_count, input_file_size, parameters, requested_time, processors, memory, comments, job_submitted_time, error)
-        values
-        ('$job_id', '$job_name', '$STATUS', $ID, 'Pipeline', 'GSQ ', '$app_id', '$job_url', '$HPC_name', '$username', '$admin_email', '$type', '$genome_file_size', '$total_scaffold_count', '$splitSize', '$input_file_size', '$parameters', '$requested_time', '$total_threads', '$memory_per_node', '$comment', '$submitted', 'job submission FAILED - http code: $http_code - response: $response_display')";
-    
-        $do_statement = mysql_query($statement);
-        error_log("\n Updated jobs as follows:".$statement." Success=".$do_statement." \n \n");
+		$statement="Insert into $global_DB1.jobs 
+		(job_id, job_name, status, db_id, job_type, program, softwareName, job_URL, HPC_name, user, admin_email, seq_type, genome_file_size, genome_segments, split_count, input_file_size, parameters, requested_time, processors, memory, comments, job_submitted_time, error)
+		values
+		('$job_id', '$job_name', '$STATUS', $ID, 'Pipeline', 'GSQ ', '$app_id', '$job_url', '$HPC_name', '$username', '$admin_email', '$type', '$genome_file_size', '$total_scaffold_count', '$splitSize', '$input_file_size', '$parameters', '$requested_time', '$total_threads', '$memory_per_node', '$comment', '$submitted', 'job submission FAILED - http code: $http_code - response: $response_display')";
+	
+		$do_statement = mysql_query($statement);
+error_log("\n Updated jobs as follows:".$statement." Success=".$do_statement." \n \n");
 
-        $job_id_query = "update $global_DB2.xGDB_Log set $gsq_job = '$job_id', $gsq_job_result ='error' where ID=$ID"; // read by xGDB_Procedure.sh     
-        $job_id_update = mysql_query($job_id_query);  
+		$job_id_query = "update $global_DB2.xGDB_Log set $gsq_job = '$job_id', $gsq_job_result ='error' where ID=$ID"; // read by xGDB_Procedure.sh		
+		$job_id_update = mysql_query($job_id_query);  
 
-        error_log("\n Updated xGDB_Log as follows:".$job_id_query." Success=".$job_id_update." \n \n");
-    }
+error_log("\n Updated xGDB_Log as follows:".$job_id_query." Success=".$job_id_update." \n \n");
+
+	}
  //destroy php curl object 
-    curl_close ($ch);
+	curl_close ($ch);
 }
 ?>

--- a/scripts/gth_remote.php
+++ b/scripts/gth_remote.php
@@ -8,11 +8,12 @@ It communicates with a wrapper script that parses json output to create a GTH co
 Input  directories are fixed so that the xGDBvm pipeline can deposit input files from standardized pathnames.
 Output is sent by default to the users' DataStore directory /archive/jobs/
 Parameter names/values included in the json string are below (some user-configurable, others not)
+Updated 7-11-2016 JDuvick
 */
 
 include('sitedef.php');
 include_once('/xGDBvm/XGDB/phplib/db.inc.php'); #reads MySQL password from /xGDBvm/admin/dbpass
-include_once('/xGDBvm/XGDB/jobs/jobs_functions.inc.php'); # to estimate file sizes
+include_once('/xGDBvm/XGDB/jobs/jobs_functions.inc.php'); # to estimate file sizes and other functions
 include_once('/xGDBvm/XGDB/jobs/login_functions.inc.php'); # To get refresh token
 
 $inputDIR=$XGDB_INPUTDIR; # 1-26-2016 e.g. /xGDBvm/input/xgdbvm/
@@ -194,12 +195,12 @@ echo "\n DBid=$DBid \n";
 	{
 		$auth_error .= "No access token could be obtained; ";
 	}
-	if ($auth_error!="")
-	{
-	error_log("\n Authentication FAILED - ".$auth_error."\n");
-	}
-	else
-	{
+if ($auth_error!="")
+{
+error_log("\n Authentication FAILED - ".$auth_error."\n");
+}
+else
+{
 ############## Part IV. Populate CURL object and submit #############
 
 	error_log("\n Authentication returned http_code $http_code.\n"); #  
@@ -219,43 +220,8 @@ echo "\n DBid=$DBid \n";
     $callbackUrl="https://".$server."/XGDB/jobs/webhook.php?nonce=".$nonce."&ID=".$ID."&type=prot&job_id=\${JOB_ID}&status=\${JOB_STATUS}&error=\${JOB_ERROR}"; // this script will update status in MySQL tables monitored by the pipeline
 	//Setting post array that we will jsonify. See http://agaveapi.co/live-docs/#!/jobs/submit_post_1
 
-	//If amin_email missing, don't include email webhooks.
+$notifications = build_notifications_array($callbackUrl, $admin_email); # see jobs_functions.inc.php; an array for alerts to the VM / user (if admin email configured)
 
-	$notifications=($admin_email=="")
-	?
-	array
-		   (
-				array(
-				   "url" =>  "$callbackUrl",
-				   "event" => "*",
-				   "persistent" => true
-				)
-			)
-	:
-	array
-		   (
-			   array(
-					 "url" => "$admin_email",
-					 "event" => "RUNNING",
-				   "persistent" => false
-				),
-				array(
-				   "url" => "$admin_email",
-				   "event" =>  "FAILED",
-				   "persistent" => false
-				),
-				array(
-				   "url" => "$admin_email",
-				   "event" =>  "FINISHED",
-				   "persistent" => false
-				),
-				array(
-				   "url" =>  "$callbackUrl",
-				   "event" => "*",
-				   "persistent" => true
-				)
-			)
-	;
 	//create array
 		$job_data = array
 		(
@@ -291,10 +257,7 @@ echo "\n DBid=$DBid \n";
 		curl_setopt($ch, CURLOPT_POST, true);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $postField );
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array( "Content-Type:application/json", "Authorization: Bearer  $access_token"));
-	 $attempts=0;
-	 $max_attempts=5;
-     for ($i = 1; $i <= $max_attempts; $i++)
-     {
+
 	//Execute the php curl and grab the response
 		$response = curl_exec($ch);
 		$resultStatus = curl_getinfo($ch);
@@ -309,12 +272,7 @@ echo "\n DBid=$DBid \n";
 
 	#/* comment out this block to debug
 	$http_code=$resultStatus['http_code'];
-	$attempts=$attempts+1;
-	if($http_code == 200 || $http_code == 201)
-	break;
-	sleep(30);
-	}
-	// After up to 5 tries, 
+	
 	if($http_code == 200 || $http_code == 201)
 	{
 		$message=$handled_json['result']['message']; // status message
@@ -330,8 +288,7 @@ echo "\n DBid=$DBid \n";
 		$status=strtolower($STATUS); # for styling
 		$nodeCount=$handled_json['nodeCount']; #not using this at present
 		$archive_path=($STATUS=="PENDING")?"/${username}/archive/jobs/job-${job_id}/":"N/A";
-		$comment="$attempts attempts; ";
-        $comment.="${STATUS}: $submit_time | "; // This is the actual submit time returned by the server. Subsequent status updates will be concatenated here.
+        $comment="${STATUS}: $submit_time | "; // This is the actual submit time returned by the server. Subsequent status updates will be concatenated here.
 		// Store job data in Admin.jobs database table.
 
 		$statement="Insert into $global_DB1.jobs (nonce, job_id, job_name, status, db_id, job_type, program, softwareName, job_URL, HPC_name, user, admin_email, seq_type, genome_file_size, 
@@ -358,22 +315,21 @@ error_log("\n gth_remote.php cURL SUCCEEDED. Submitted to URL:".$job_url." \n po
 	else
 	{ //Curl submit failed
 
-        error_log("\n gth_remote.php FAILED. cURL submitted to URL:".$job_url." http_code=".$http_code." \n \n postField=".$postField."\n \n parameters=".$parameters."\n \n message=".$message."\n \n response=".$response."\n \n");
+error_log("\n gth_remote.php FAILED. cURL submitted to URL:".$job_url." http_code=".$http_code." \n \n postField=".$postField."\n \n parameters=".$parameters."\n \n message=".$message."\n \n response=".$response."\n \n");
 		$STATUS="ERROR";
 		$status=$handled_json['status'];// error is the typical response (NOTE: this is different from $STATUS where a job has been successfully submitted)
-		$comment="$attempts attempts; ";
-		$comment .= $handled_json['message'];// Failed to submit job is the typical response
+		$message=$handled_json['message'];// Failed to submit job is the typical response
 	
 # Create job_name, a text identifier for failed job (no job ID assigned, so just use failure result, e.g. 'null')
 		$job_id ="error-".$job_name; // combination of 'null' and local job name. e.g. error-Q2Ejd-20130313-203456
 		
-        $response_display = str_replace('>', ' ', (str_replace('>', ' ', $response))); // we will be displaying this in a table; it may be formatted
+$response_display = str_replace('>', ' ', (str_replace('>', ' ', $response))); // we will be displaying this in a table; it may be formatted
 
 # Store job data in Admin.jobs database table.
 		$statement="Insert into $global_DB1.jobs 
 		(job_id, job_name, status, db_id, job_type, program, softwareName, job_URL, HPC_name, user, admin_email, seq_type, genome_file_size, genome_segments, split_count, input_file_size, parameters, requested_time, processors, memory, comments, job_submitted_time, error)
 		values
-		('$job_id', '$job_name', '$STATUS', $ID, 'Pipeline', 'GTH ', '$app_id', '$job_url', '$HPC_name', '$username', '$admin_email', '$type', '$genome_file_size', '$total_scaffold_count', '$splitSize', '$input_file_size', '$parameters', '$requested_time', '$proc_per_node', '$memory_per_node', '$comment', '$submitted', 'job submission FAILED - http code: $http_code - response: $response_display')";
+		('$job_id', '$job_name', '$STATUS', $ID, 'Pipeline', 'GTH ', '$app_id', '$job_url', '$HPC_name', '$username', '$admin_email', '$type', '$genome_file_size', '$total_scaffold_count', '$splitSize', '$input_file_size', '$parameters', '$requested_time', '$proc_per_node', '$memory_per_node', '$message', '$submitted', 'job submission FAILED - http code: $http_code - response: $response_display')";
 	
 		$do_statement = mysql_query($statement);
 


### PR DESCRIPTION
A user case was reported in which a HPC job submitted as part of a workflow failed to register as status="FINISHED" even though the job did complete and data were deposited in the archive.  Examining the status log, it appears the 'FINISHED' command that informs xGDB_Procedure.sh to exit the 'wait for data' loop was never received, even though it presumably was submitted by the Agave API.  TACC staff confirmed  that one of two status messages (the 'FINISH' status) was not sent successfully, and suggested updating the JSON notifications string with code that specifies a persistent submission behavior.  This was done by creating a function specifying an array equivalent to the modified JSON notification string in jobs_functions.inc.php, and calling this function in each of the four scripts that launches remote jobs for use in creating the final JSON string sent with each job submission. The scripts work as expected with example data (both standalone and workflow versions) although the persistence feature cannot be verified to work since it seems to be an unusual point of failure (one that I had never seen in all my testing).
